### PR TITLE
src: Resize filesystem after writing ext2/3/4 file

### DIFF
--- a/src/emmc.c
+++ b/src/emmc.c
@@ -264,6 +264,8 @@ pu_emmc_write_data(PuFlash *flash,
                 pu_umount(part_mount);
                 if (!pu_write_raw(path, part_path, self->device, 0, 0, error))
                     return FALSE;
+                if (!pu_resize_filesystem(part_path, error))
+                    return FALSE;
                 pu_mount(part_path, part_mount);
                 continue;
             } else {

--- a/src/utils.c
+++ b/src/utils.c
@@ -106,6 +106,20 @@ pu_make_filesystem(const gchar *part,
 }
 
 gboolean
+pu_resize_filesystem(const gchar *part,
+                     GError **error)
+{
+    g_autofree gchar *cmd = NULL;
+
+    g_return_val_if_fail(part != NULL, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    cmd = g_strdup_printf("resize2fs %s", part);
+
+    return pu_spawn_command_line_sync(cmd, error);
+}
+
+gboolean
 pu_write_raw(const gchar *input_path,
              const gchar *output_path,
              PedDevice *device,

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,6 +18,8 @@ gboolean pu_archive_extract(const gchar *filename,
 gboolean pu_make_filesystem(const gchar *part,
                             const gchar *type,
                             GError **error);
+gboolean pu_resize_filesystem(const gchar *part,
+                              GError **error);
 gboolean pu_write_raw(const gchar *input_path,
                       const gchar *output_path,
                       PedDevice *device,


### PR DESCRIPTION
Resize the filesystem after writing an ext2/3/4 file to utilize the whole partition.

Signed-off-by: Leonard Anderweit <l.anderweit@phytec.de>