### PR TITLE
src: emmc: Add configurable size alignment for expanding partitions

### DIFF
--- a/doc/layout-config.rst
+++ b/doc/layout-config.rst
@@ -59,6 +59,10 @@ options:
 ``offset`` (integer/string)
    The offset of a partition.
 
+``block-size`` (integer/string)
+   Set the partition size to a multiple of the specified value. The default is
+   2 sectors, which is almost always equal to 1KiB.
+
 ``input`` (sequence)
    A sequence of input mappings. See :ref:`input-files`.
 


### PR DESCRIPTION
Add size alignment for expanding partitions. The alignment can be
configured with for each partition individually with 'align'. The
default alignment is 1KiB.