### PR TITLE
src: Use GError for mount.c

### DIFF
--- a/src/emmc.c
+++ b/src/emmc.c
@@ -252,11 +252,9 @@ pu_emmc_write_data(PuFlash *flash,
             continue;
         }
 
-        part_mount = pu_create_mount_point(g_strdup_printf("p%u", i));
-        if (part_mount == NULL) {
-            g_warning("Failed creating mount point");
-            continue;
-        }
+        part_mount = pu_create_mount_point(g_strdup_printf("p%u", i), error);
+        if (part_mount == NULL)
+            return FALSE;
 
         for (GList *i = part->input; i != NULL; i = i->next) {
             PuEmmcInput *input = i->data;
@@ -270,10 +268,12 @@ pu_emmc_write_data(PuFlash *flash,
 
             if (g_regex_match_simple(".tar", path, G_REGEX_CASELESS, 0)) {
                 g_debug("Extracting '%s' to '%s'", path, part_mount);
-                pu_mount(part_path, part_mount);
+                if (!pu_mount(part_path, part_mount, error))
+                    return FALSE;
                 if (!pu_archive_extract(path, part_mount, error))
                     return FALSE;
-                pu_umount(part_mount);
+                if (!pu_umount(part_mount, error))
+                    return FALSE;
             } else if (g_regex_match_simple(".ext[234]$", path, 0, 0)) {
                 g_debug("Writing '%s' to '%s'", path, part_mount);
                 if (!pu_write_raw(path, part_path, self->device, 0, 0, error))
@@ -283,10 +283,12 @@ pu_emmc_write_data(PuFlash *flash,
                 continue;
             } else {
                 g_debug("Copying '%s' to '%s'", path, part_mount);
-                pu_mount(part_path, part_mount);
+                if (!pu_mount(part_path, part_mount, error))
+                    return FALSE;
                 if (!pu_file_copy(path, part_mount, error))
                     return FALSE;
-                pu_umount(part_mount);
+                if (!pu_umount(part_mount, error))
+                    return FALSE;
             }
 
             g_autofree gchar *output =

--- a/src/mount.h
+++ b/src/mount.h
@@ -10,10 +10,13 @@
 
 #define PU_MOUNT_PREFIX "/mnt/partup"
 
-gchar * pu_create_mount_point(const gchar *name);
+gchar * pu_create_mount_point(const gchar *name,
+                              GError **error);
 gboolean pu_mount(const gchar *source,
-                  const gchar *mount_point);
-gboolean pu_umount(const gchar *mount_point);
+                  const gchar *mount_point,
+                  GError **error);
+gboolean pu_umount(const gchar *mount_point,
+                   GError **error);
 gboolean pu_device_mounted(const gchar *device);
 
 #endif /* PARTUP_MOUNT_H */


### PR DESCRIPTION
Use GError in all functions implemented in mount.c to capture error messages and adjust all uses of the functions accordingly.

Signed-off-by: Leonard Anderweit <l.anderweit@phytec.de>