### PR TITLE
Verify checksum before writing data

### DIFF
--- a/doc/layout-config.rst
+++ b/doc/layout-config.rst
@@ -109,8 +109,8 @@ optional checksum can be provided with ``md5sum`` and/or ``sha256sum``.
 
 ``md5sum`` (string)
    The MD5 sum of the given file specified by ``uri``. This sum is checked
-   against the written file on the target partition or volume.
+   against the provided file before writing to the target partition or volume.
 
 ``sha256sum`` (string)
    The SHA256 sum of the given file specified by ``uri``. This sum is checked
-   against the written file on the target partition or volume.
+   against the provided file before writing to the target partition or volume.


### PR DESCRIPTION
Verify the checksum of input files before writing to partitions. This
allows verification of archives and raw partition files. This also fixes
the issue of partitions not being mounted for checksum verification.

Signed-off-by: Leonard Anderweit <l.anderweit@phytec.de>

Requires #7 to be merged first.