### PR TITLE
doc: usage: Note "prefix" option

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -17,4 +17,5 @@ When executing partup, the following options can be specified:
 -h, --help              Show help options
 -c, --config=CONFIG     Layout configuration file in YAML format
 -d, --debug             Print debug messages
+-p, --prefix=PREFIX     Path to prefix all file URIs with in the layout configuration
 -v, --version           Print the program version and exit


### PR DESCRIPTION
Note option "prefix" for specifying a path which is prepended to relative input URIs in the layout configuration file.

Signed-off-by: Leonard Anderweit <l.anderweit@phytec.de>