### PR TITLE
Document install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,14 @@ Build the documentation::
 
    ninja -C build doc/html
 
+Installation
+============
+
+Install partup on the current system. If enabled, the documentation will be
+installed as well::
+
+   meson install -C build
+
 License
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,11 @@ installed as well::
 
    meson install -C build
 
+Yocto Integration
+-----------------
+
+A Yocto recipe is available in `meta-ampliphy <https://git.phytec.de/meta-ampliphy/tree/recipes-devtools/partup>`_.
+
 License
 =======
 


### PR DESCRIPTION
Add installation instructions for partup and the documentation. partup is installed in /usr/bin and the documentation in /usr/share/doc.