### PR TITLE
Add option to clean space on the device

### DIFF
--- a/doc/layout-config.rst
+++ b/doc/layout-config.rst
@@ -14,6 +14,19 @@ API Version
 MMC Options
 -----------
 
+Clean Data
+..........
+
+The seciton ``clean`` contains a sequence of mappings describing where the mmc
+device is cleaned outside of partitions. Each entry should contain the
+following options:
+
+``offset`` (integer/string)
+   Offset of the cleaned space.
+
+``size`` (integer/string)
+   Size of the cleaned space.
+
 Raw Data
 ........
 

--- a/src/emmc.c
+++ b/src/emmc.c
@@ -305,7 +305,7 @@ pu_emmc_write_data(PuFlash *flash,
                     return FALSE;
             } else if (g_regex_match_simple(".ext[234]$", path, 0, 0)) {
                 g_debug("Writing '%s' to '%s'", path, part_mount);
-                if (!pu_write_raw(path, part_path, self->device, 0, 0, error))
+                if (!pu_write_raw(path, part_path, self->device, 0, 0, 0, error))
                     return FALSE;
                 if (!pu_resize_filesystem(part_path, error))
                     return FALSE;
@@ -352,7 +352,7 @@ pu_emmc_write_data(PuFlash *flash,
         }
 
         if (!pu_write_raw(path, self->device->path, self->device,
-                          bin->input_offset, bin->output_offset, error))
+                          bin->input_offset, bin->output_offset, 0, error))
             return FALSE;
     }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -25,6 +25,7 @@ gboolean pu_write_raw(const gchar *input_path,
                       PedDevice *device,
                       PedSector input_offset,
                       PedSector output_offset,
+                      PedSector size,
                       GError **error);
 gboolean pu_write_raw_bootpart(const gchar *input,
                                PedDevice *device,


### PR DESCRIPTION
Add section 'clean' to layout configuration which deletes content at the
specified location.

Example for deleting the environment saved by u-boot on i.MX8M*:

clean:
  - offset: 3840KiB
    size: 64KiB
  - offset: 3960KiB
    size: 64KiB