### PR TITLE
Rework debug output

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -14,9 +14,9 @@ Option List
 
 When executing partup, the following options can be specified:
 
--h, --help              Show help options
--c, --config=CONFIG     Layout configuration file in YAML format
--d, --debug             Print debug messages
--p, --prefix=PREFIX     Path to prefix all file URIs with in the layout configuration
--s, --skip-checksums    Skip checksum verification for all input files
--v, --version           Print the program version and exit
+-h, --help                  Show help options
+-c, --config=CONFIG         Layout configuration file in YAML format
+-d, --debug=DEBUG-DOMAINS   Comma separated list of modules for to enable debug output
+-p, --prefix=PREFIX         Path to prefix all file URIs with in the layout configuration
+-s, --skip-checksums        Skip checksum verification for all input files
+-v, --version               Print the program version and exit

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -18,5 +18,6 @@ When executing partup, the following options can be specified:
 -c, --config=CONFIG         Layout configuration file in YAML format
 -d, --debug=DEBUG-DOMAINS   Comma separated list of modules for to enable debug output
 -p, --prefix=PREFIX         Path to prefix all file URIs with in the layout configuration
+-q, --quiet                 Print only error messages
 -s, --skip-checksums        Skip checksum verification for all input files
 -v, --version               Print the program version and exit

--- a/src/config.c
+++ b/src/config.c
@@ -10,6 +10,8 @@
 #include "config.h"
 #include "error.h"
 
+#define G_LOG_DOMAIN "partup-config"
+
 typedef struct _PuConfigPrivate PuConfigPrivate;
 
 struct _PuConfigPrivate {

--- a/src/emmc.c
+++ b/src/emmc.c
@@ -12,6 +12,8 @@
 #include "utils.h"
 #include "emmc.h"
 
+#define G_LOG_DOMAIN "partup-emmc"
+
 typedef struct _PuEmmcInput {
     gchar *uri;
     gchar *md5sum;

--- a/src/emmc.c
+++ b/src/emmc.c
@@ -96,7 +96,7 @@ emmc_create_partition(PuEmmc *self,
             return FALSE;
         }
         if (ped_disk_extended_partition(self->disk) == NULL) {
-            g_debug("Creating extended partition at %lld", start);
+            g_message("Creating extended partition at %lld", start);
             PedPartition *extpart;
             gint ret;
 
@@ -266,13 +266,13 @@ pu_emmc_write_data(PuFlash *flash,
         if (part_path == NULL)
             return FALSE;
 
-        g_debug("Creating filesystem %s on %s", part->filesystem, part_path);
+        g_message("Creating filesystem %s on %s", part->filesystem, part_path);
 
         if (!pu_make_filesystem(part_path, part->filesystem, error))
             return FALSE;
 
         if (!part->input) {
-            g_debug("No input specified. Skipping %s", part_path);
+            g_message("No input specified. Skipping %s", part_path);
             continue;
         }
 
@@ -291,20 +291,20 @@ pu_emmc_write_data(PuFlash *flash,
             }
 
             if (!g_str_equal(input->md5sum, "") && !skip_checksums) {
-                g_debug("Checking MD5 sum of input file '%s'", path);
+                g_info("Checking MD5 sum of input file '%s'", path);
                 if (!pu_checksum_verify_file(path, input->md5sum,
                                              G_CHECKSUM_MD5, error))
                     return FALSE;
             }
             if (!g_str_equal(input->sha256sum, "") && !skip_checksums) {
-                g_debug("Checking SHA256 sum of input file '%s'", path);
+                g_info("Checking SHA256 sum of input file '%s'", path);
                 if (!pu_checksum_verify_file(path, input->sha256sum,
                                              G_CHECKSUM_SHA256, error))
                     return FALSE;
             }
 
             if (g_regex_match_simple(".tar", path, G_REGEX_CASELESS, 0)) {
-                g_debug("Extracting '%s' to '%s'", path, part_mount);
+                g_message("Extracting '%s' to '%s'", path, part_mount);
                 if (!pu_mount(part_path, part_mount, error))
                     return FALSE;
                 if (!pu_archive_extract(path, part_mount, error))
@@ -312,13 +312,13 @@ pu_emmc_write_data(PuFlash *flash,
                 if (!pu_umount(part_mount, error))
                     return FALSE;
             } else if (g_regex_match_simple(".ext[234]$", path, 0, 0)) {
-                g_debug("Writing '%s' to '%s'", path, part_mount);
+                g_message("Writing '%s' to '%s'", path, part_mount);
                 if (!pu_write_raw(path, part_path, self->device, 0, 0, 0, error))
                     return FALSE;
                 if (!pu_resize_filesystem(part_path, error))
                     return FALSE;
             } else {
-                g_debug("Copying '%s' to '%s'", path, part_mount);
+                g_message("Copying '%s' to '%s'", path, part_mount);
                 if (!pu_mount(part_path, part_mount, error))
                     return FALSE;
                 if (!pu_file_copy(path, part_mount, error))
@@ -361,13 +361,13 @@ pu_emmc_write_data(PuFlash *flash,
         }
 
         if (!g_str_equal(input->md5sum, "") && !skip_checksums) {
-            g_debug("Checking MD5 sum of input file '%s'", path);
+            g_info("Checking MD5 sum of input file '%s'", path);
             if (!pu_checksum_verify_file(path, input->md5sum,
                                          G_CHECKSUM_MD5, error))
                 return FALSE;
         }
         if (!g_str_equal(input->sha256sum, "") && !skip_checksums) {
-            g_debug("Checking SHA256 sum of input file '%s'", path);
+            g_info("Checking SHA256 sum of input file '%s'", path);
             if (!pu_checksum_verify_file(path, input->sha256sum,
                                          G_CHECKSUM_SHA256, error))
                 return FALSE;
@@ -395,13 +395,13 @@ pu_emmc_write_data(PuFlash *flash,
         }
 
         if (!g_str_equal(input->md5sum, "") && !skip_checksums) {
-            g_debug("Checking MD5 sum of input file '%s'", path);
+            g_info("Checking MD5 sum of input file '%s'", path);
             if (!pu_checksum_verify_file(path, input->md5sum,
                                          G_CHECKSUM_MD5, error))
                 return FALSE;
         }
         if (!g_str_equal(input->sha256sum, "") && !skip_checksums) {
-            g_debug("Checking SHA256 sum of input file '%s'", path);
+            g_info("Checking SHA256 sum of input file '%s'", path);
             if (!pu_checksum_verify_file(path, input->sha256sum,
                                          G_CHECKSUM_SHA256, error))
                 return FALSE;
@@ -508,7 +508,7 @@ pu_emmc_parse_emmc_bootpart(PuEmmc *emmc,
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
     if (!value_bootpart) {
-        g_debug("No entry 'emmc-boot-partitions' found. Skipping...");
+        g_message("No entry 'emmc-boot-partitions' found. Skipping...");
         return TRUE;
     }
 
@@ -568,7 +568,7 @@ pu_emmc_parse_clean(PuEmmc *emmc,
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
     if (!value_clean) {
-        g_debug("No entry 'clean' found. Skipping...");
+        g_message("No entry 'clean' found. Skipping...");
         return TRUE;
     }
 
@@ -607,7 +607,7 @@ pu_emmc_parse_raw(PuEmmc *emmc,
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
     if (!value_raw) {
-        g_debug("No entry 'raw' found. Skipping...");
+        g_message("No entry 'raw' found. Skipping...");
         return TRUE;
     }
 
@@ -668,7 +668,7 @@ pu_emmc_parse_partitions(PuEmmc *emmc,
     emmc->num_expanded_parts = 0;
 
     if (!value_partitions) {
-        g_debug("No entry 'partitions' found. Skipping...");
+        g_message("No entry 'partitions' found. Skipping...");
         return TRUE;
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,7 @@
 #include "utils.h"
 #include "version.h"
 
+static gboolean arg_quiet = FALSE;
 static gboolean arg_version = FALSE;
 static gboolean arg_skip_checksums = FALSE;
 static gchar *arg_config = NULL;
@@ -49,6 +50,8 @@ static GOptionEntry option_entries[] = {
     { "prefix", 'p', G_OPTION_FLAG_NONE, G_OPTION_ARG_FILENAME,
         &arg_prefix, "Path to prefix all file URIs with in the layout configuration",
         "PREFIX" },
+    { "quiet", 'q', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
+        &arg_quiet, "Print only error messages", NULL },
     { "skip-checksums", 's', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
         &arg_skip_checksums, "Skip checksum verification for all input files", NULL },
     { "version", 'v', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
@@ -80,6 +83,10 @@ main(G_GNUC_UNUSED int argc,
     if (!g_option_context_parse_strv(context, &args, &error)) {
         g_printerr("Failed parsing options: %s\n", error->message);
         return 1;
+    }
+
+    if (arg_quiet) {
+        g_log_set_writer_func(g_log_writer_journald, NULL, NULL);
     }
 
     if (arg_debug) {

--- a/src/mount.c
+++ b/src/mount.c
@@ -12,6 +12,8 @@
 #include "error.h"
 #include "mount.h"
 
+#define G_LOG_DOMAIN "partup-mount"
+
 gchar *
 pu_create_mount_point(const gchar *name,
                       GError **error)

--- a/src/mount.c
+++ b/src/mount.c
@@ -23,7 +23,7 @@ pu_create_mount_point(const gchar *name,
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
     if (g_file_test(mount_point, G_FILE_TEST_IS_DIR)) {
-        g_debug("Mount point '%s' already exists", mount_point);
+        g_info("Mount point '%s' already exists", mount_point);
         return mount_point;
     }
 


### PR DESCRIPTION
Rework debug output by introducing additional log domains for which debug output can be enabled separately. 
Also, introduce a new option `quiet` to suppress output to stdout and instead redirect messages to the journal.