### PR TITLE
Support setting PARTUUID

### DIFF
--- a/doc/layout-config-reference.rst
+++ b/doc/layout-config-reference.rst
@@ -56,6 +56,10 @@ options:
 ``label`` (string)
    A partition label.
 
+``partuuid`` (string)
+   The PARTUUID of the partition. Only supported on GPT partitioned devices. A
+   random UUID is used by default.
+
 ``type`` (string)
    The partition type. May be one of ``primary`` or ``logical``. Note, that with
    the first occurrence of a logical partition the following ones must be

--- a/src/utils.c
+++ b/src/utils.c
@@ -307,6 +307,31 @@ pu_bootpart_enable(const gchar *device,
     return pu_spawn_command_line_sync(cmd, error);
 }
 
+gboolean
+pu_partition_set_partuuid(const gchar *device,
+                          guint index,
+                          const gchar *partuuid,
+                          GError **error)
+{
+    g_autofree gchar *cmd = NULL;
+
+    g_return_val_if_fail(g_strcmp0(device, "") > 0, FALSE);
+    g_return_val_if_fail(index > 0, FALSE);
+    g_return_val_if_fail(g_strcmp0(partuuid, "") > 0, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    cmd = g_strdup_printf("sfdisk --part-uuid %s %d %s",
+                          device, index, partuuid);
+
+    if (!pu_spawn_command_line_sync(cmd, error)) {
+        g_prefix_error(error, "Failed setting PARTUUID on %s partition %d: ",
+                       device, index);
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
 gchar *
 pu_path_from_uri(const gchar *uri,
                  const gchar *prefix,

--- a/src/utils.h
+++ b/src/utils.h
@@ -36,6 +36,10 @@ gboolean pu_write_raw_bootpart(const gchar *input,
 gboolean pu_bootpart_enable(const gchar *device,
                             guint bootpart,
                             GError **error);
+gboolean pu_partition_set_partuuid(const gchar *device,
+                                   guint index,
+                                   const gchar *partuuid,
+                                   GError **error);
 gchar * pu_path_from_uri(const gchar *uri,
                          const gchar *prefix,
                          GError **error);


### PR DESCRIPTION
The PARTUUID of partitions can be set for each individual GPT partition.
It is implemented with a new mapping `partuuid:` for partitions.
This creates a dependency on `sfdisk` provided by `util-linux` on ubunto and `util-linux-sfdisk" on yocto.