### PR TITLE
src: mount: Use libmount for mounting

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,8 @@ deps = [
   dependency('gio-2.0'),
   dependency('yaml-0.1'),
   dependency('libparted'),
-  dependency('mount')
+  dependency('mount'),
+  dependency('blkid')
 ]
 src = [
   'src/checksum.c',

--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,8 @@ deps = [
   dependency('glib-2.0', version : '>=2.66.0'),
   dependency('gio-2.0'),
   dependency('yaml-0.1'),
-  dependency('libparted')
+  dependency('libparted'),
+  dependency('mount')
 ]
 src = [
   'src/checksum.c',

--- a/src/error.h
+++ b/src/error.h
@@ -31,7 +31,10 @@ typedef enum {
     PU_ERROR_CHECKSUM,
 
     /* Utility errors */
-    PU_ERROR_UNKNOWN_FSTYPE
+    PU_ERROR_UNKNOWN_FSTYPE,
+
+    /* Mount error */
+    PU_ERROR_MOUNT
 } PuErrorEnum;
 
 GQuark pu_error_quark(void);

--- a/src/main.c
+++ b/src/main.c
@@ -66,6 +66,7 @@ main(G_GNUC_UNUSED int argc,
     g_autoptr(PuConfig) config = NULL;
     g_autoptr(PuEmmc) emmc = NULL;
     g_autofree gchar **args;
+    gboolean is_mounted;
     gint api_version;
     const gchar *prog_name = g_path_get_basename(argv[0]);
 
@@ -113,7 +114,12 @@ main(G_GNUC_UNUSED int argc,
         return 1;
     }
 
-    if (pu_device_mounted(arg_device)) {
+    if (!pu_device_mounted(arg_device, &is_mounted, &error)) {
+        g_printerr("Failed checking if device is in use: %s\n", error->message);
+        return 1;
+    }
+
+    if (is_mounted) {
         g_printerr("Device '%s' is in use!\n", arg_device);
         return 1;
     }

--- a/src/mount.c
+++ b/src/mount.c
@@ -186,7 +186,9 @@ pu_umount_all(const gchar *device,
 }
 
 gboolean
-pu_device_mounted(const gchar *device)
+pu_device_mounted(const gchar *device,
+                  gboolean *is_mounted,
+                  GError **error)
 {
     g_autoptr(GPtrArray) mounted = NULL;
 
@@ -194,12 +196,12 @@ pu_device_mounted(const gchar *device)
 
     mounted = pu_find_mounted(device);
     if (!mounted) {
-        g_printerr("Failed checking if device is mounted");
-        return TRUE;
+        g_set_error(error, PU_ERROR, PU_ERROR_MOUNT,
+                    "Failed checking if device '%s' is mounted", device);
+        return FALSE;
     }
 
-    if (!mounted->len)
-        return FALSE;
+    *is_mounted = mounted->len > 0;
 
     return TRUE;
 }

--- a/src/mount.c
+++ b/src/mount.c
@@ -188,10 +188,18 @@ pu_umount_all(const gchar *device,
 gboolean
 pu_device_mounted(const gchar *device)
 {
-    g_autofree gchar *cmd = g_strdup("mount");
-    g_autofree gchar *output = NULL;
+    g_autoptr(GPtrArray) mounted = NULL;
 
-    g_spawn_command_line_sync(cmd, &output, NULL, NULL, NULL);
+    g_return_val_if_fail(g_strcmp0(device, "") > 0, FALSE);
 
-    return g_regex_match_simple(device, output, G_REGEX_MULTILINE, 0);
+    mounted = pu_find_mounted(device);
+    if (!mounted) {
+        g_printerr("Failed checking if device is mounted");
+        return TRUE;
+    }
+
+    if (!mounted->len)
+        return FALSE;
+
+    return TRUE;
 }

--- a/src/mount.h
+++ b/src/mount.h
@@ -19,6 +19,8 @@ gboolean pu_umount(const gchar *mount_point,
                    GError **error);
 gboolean pu_umount_all(const gchar *device,
                        GError **error);
-gboolean pu_device_mounted(const gchar *device);
+gboolean pu_device_mounted(const gchar *device,
+                           gboolean *is_mounted,
+                           GError **error);
 
 #endif /* PARTUP_MOUNT_H */


### PR DESCRIPTION
Use libmount from util-linux for mount operations instead of calling mount and umount in a commandline.

Signed-off-by: Leonard Anderweit <l.anderweit@phytec.de>