### PR TITLE
Test partup with loop device in github action

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -1,0 +1,50 @@
+name: system-tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  system-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install meson libglib2.0-dev libyaml-dev libparted-dev
+      - name: Build and install application
+        run: |
+          meson setup build --buildtype=release
+          meson install -C build
+      - name: Setup loopdev
+        run: |
+          dd if=/dev/zero of=loop-file bs=1M count=100
+          echo "loop_dev=$(sudo losetup -f --show -P loop-file)" >> $GITHUB_ENV
+      - name: Run system tests with loop device
+        timeout-minutes: 2
+        run: |
+          for f in tests/config/system-tests/*
+          do
+            echo "Testing with $f"
+            echo "Create package"
+            cp $f tests/data/layout.yaml
+            G_DEBUG=fatal-warnings partup -d -C tests/data package pkg.partup \
+              layout.yaml random.bin lorem.txt lorem.tar root.ext4
+            echo "Show package content"
+            sudo G_DEBUG=fatal-warnings partup -s show pkg.partup
+            echo "Install package to loop device"
+            sudo G_DEBUG=fatal-warnings partup -d install pkg.partup ${{ env.loop_dev }}
+            echo "Show loop device info"
+            sudo fdisk -l ${{ env.loop_dev }}
+            sudo blkid ${{ env.loop_dev }}
+            git clean -xdf -e loop-file
+          done
+      - name: Remove loopdev
+        if: always()
+        run: |
+          sudo losetup -d ${{ env.loop_dev }}
+          rm loop-file

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ partup - System Initialization Program
    :target: https://github.com/phytec/partup/actions/workflows/build.yml
 .. image:: https://github.com/phytec/partup/workflows/unit-tests/badge.svg
    :target: https://github.com/phytec/partup/actions/workflows/unit-tests.yml
+.. image:: https://github.com/phytec/partup/workflows/system-tests/badge.svg
+   :target: https://github.com/phytec/partup/actions/workflows/system-tests.yml
 .. image:: https://github.com/phytec/partup/workflows/documentation/badge.svg
    :target: https://github.com/phytec/partup/actions/workflows/documentation.yml
 

--- a/tests/config/system-tests/gpt.yaml
+++ b/tests/config/system-tests/gpt.yaml
@@ -1,0 +1,27 @@
+api-version: 0
+disklabel: gpt
+
+raw:
+  - output-offset: 17kiB
+    input-offset: 0kiB
+    input:
+      uri: random.bin
+
+partitions:
+  - label: BOOT
+    partuuid: "6a69db6b-0858-404c-b42c-a58f5fb498ff"
+    filesystem: fat32
+    size: 32MiB
+    offset: 4MiB
+    input:
+      - uri: lorem.txt
+  - label: ROOT1
+    filesystem: ext4
+    expand: true
+    input:
+      - uri: lorem.tar
+  - label: ROOT
+    filesystem: null
+    expand: true
+    input:
+      - uri: root.ext4

--- a/tests/config/system-tests/msdos.yaml
+++ b/tests/config/system-tests/msdos.yaml
@@ -1,0 +1,30 @@
+api-version: 0
+disklabel: msdos
+
+raw:
+  - output-offset: 1kiB
+    input-offset: 1kiB
+    input:
+      uri: random.bin
+
+partitions:
+  - label: BOOT
+    filesystem: fat32
+    size: 16MiB
+    offset: 4MiB
+    flags:
+      - boot
+    input:
+      - uri: lorem.txt
+  - label: ROOT1
+    filesystem: ext4
+    expand: true
+    input:
+      - uri: lorem.tar
+  - label: ROOT2
+    type: logical
+    filesystem: null
+    block-size: 4kiB
+    expand: true
+    input:
+      - uri: root.ext4


### PR DESCRIPTION
Test partup by writing to loop device instead of physical device. This is a blackbox test as it tests partup as a whole.
The only change to partup itself is support for loop devices in `pu_device_get_partition_path()`.