### PR TITLE
Fix error on mkfs for first partition

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,7 @@ The following tools and libraries must be installed on the target system for
 -  `libyaml <https://pyyaml.org/wiki/LibYAML>`_
 -  `libparted <https://www.gnu.org/software/parted/>`_
 -  `util-linux <https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git>`_
+-  `udev <https://git.kernel.org/pub/scm/linux/hotplug/udev.git>`_
 
 For building *partup* from source and generating its documentation the following
 additional dependencies are needed:

--- a/src/emmc.c
+++ b/src/emmc.c
@@ -231,6 +231,9 @@ pu_emmc_setup_layout(PuFlash *flash,
 
     ped_disk_commit(self->disk);
 
+    if (!pu_wait_for_partitions(error))
+        return FALSE;
+
     return TRUE;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -21,6 +21,7 @@ pu_spawn_command_line_sync(const gchar *command_line,
     GSpawnFlags spawn_flags;
     gchar **argv = NULL;
     gint wait_status;
+    g_autofree gchar *errmsg = NULL;
 
     g_return_val_if_fail(command_line != NULL, FALSE);
 
@@ -28,9 +29,8 @@ pu_spawn_command_line_sync(const gchar *command_line,
         return FALSE;
 
     spawn_flags = G_SPAWN_SEARCH_PATH |
-                  G_SPAWN_STDOUT_TO_DEV_NULL |
-                  G_SPAWN_STDERR_TO_DEV_NULL;
-    if (!g_spawn_sync(NULL, argv, NULL, spawn_flags, NULL, NULL, NULL, NULL,
+                  G_SPAWN_STDOUT_TO_DEV_NULL;
+    if (!g_spawn_sync(NULL, argv, NULL, spawn_flags, NULL, NULL, NULL, &errmsg,
                       &wait_status, error)) {
         g_prefix_error(error, "Failed spawning process: ");
         g_strfreev(argv);
@@ -38,7 +38,8 @@ pu_spawn_command_line_sync(const gchar *command_line,
     }
 
     if (!g_spawn_check_exit_status(wait_status, error)) {
-        g_prefix_error(error, "Command '%s' failed: ", command_line);
+        g_prefix_error(error, "Command '%s' failed with error message: '%s': ",
+                       command_line, errmsg);
         g_strfreev(argv);
         return FALSE;
     }

--- a/src/utils.c
+++ b/src/utils.c
@@ -14,6 +14,8 @@
 #include "error.h"
 #include "utils.h"
 
+#define UDEVADM_SETTLE_TIMEOUT 10
+
 static gboolean
 pu_spawn_command_line_sync(const gchar *command_line,
                            GError **error)
@@ -348,6 +350,18 @@ pu_is_drive(const gchar *device)
 
     return g_regex_match_simple(g_strdup_printf("^%s$", device),
                                 output, G_REGEX_MULTILINE, 0);
+}
+
+gboolean
+pu_wait_for_partitions(GError **error)
+{
+    g_autofree gchar *udevadm_cmd = NULL;
+    udevadm_cmd = g_strdup_printf("udevadm settle --timeout %d", UDEVADM_SETTLE_TIMEOUT);
+
+    if (!pu_spawn_command_line_sync(udevadm_cmd, error))
+        return FALSE;
+
+    return TRUE;
 }
 
 gchar *

--- a/src/utils.h
+++ b/src/utils.h
@@ -41,6 +41,7 @@ gboolean pu_partition_set_partuuid(const gchar *device,
                                    const gchar *partuuid,
                                    GError **error);
 gboolean pu_is_drive(const gchar *device);
+gboolean pu_wait_for_partitions(GError **error);
 gchar * pu_path_from_uri(const gchar *uri,
                          const gchar *prefix,
                          GError **error);


### PR DESCRIPTION
Creating the filesystem on the first partition could fail when `mkfs` is called before the partition is available. Fix this by waiting for the partitions to be ready after writing the partition layout.
Also, add the output to stderr to the error message.