### PR TITLE
src: main: Remove explicit casting of arg callback

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -53,7 +53,7 @@ static GOptionEntry option_entries[] = {
     { "version", 'v', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
         &arg_version, "Print the program version and exit", NULL },
     { G_OPTION_REMAINING, 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK,
-        (void *) arg_parse_remaining, NULL, NULL },
+        arg_parse_remaining, NULL, NULL },
     { NULL }
 };
 


### PR DESCRIPTION
Remove explicit casting to void pointer of argument callback, as this is done anyway. GCC still complains about non-compliant conversion from function pointer to object pointer type:

    ISO C forbids conversion of function pointer to object pointer type

As all unit tests and examples in GLib and GTK use the same syntax, we can safely ignore this warning.