### PR TITLE
src: Add GLib compatibility header

### DIFF
--- a/src/glib-compat.h
+++ b/src/glib-compat.h
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2023 PHYTEC Messtechnik GmbH
+ */
+
+#ifndef PU_GLIB_COMPAT_H
+#define PU_GLIB_COMPAT_H
+
+#include <glib.h>
+
+#if !GLIB_CHECK_VERSION(2, 70, 0)
+#define g_spawn_check_wait_status g_spawn_check_exit_status
+#endif
+
+#endif /* PU_GLIB_COMPAT_H */

--- a/src/mount.c
+++ b/src/mount.c
@@ -10,6 +10,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include "error.h"
+#include "glib-compat.h"
 #include "mount.h"
 
 gchar *
@@ -84,7 +85,7 @@ pu_umount_all(const gchar *device,
 
     if (!g_spawn_command_line_sync(cmd_mount, &output, NULL, &wait_status, error))
         return FALSE;
-    if (!g_spawn_check_exit_status(wait_status, error))
+    if (!g_spawn_check_wait_status(wait_status, error))
         return FALSE;
 
     regex = g_regex_new(expr, G_REGEX_MULTILINE, 0, NULL);

--- a/src/utils.c
+++ b/src/utils.c
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #include "config.h"
 #include "error.h"
+#include "glib-compat.h"
 #include "utils.h"
 
 #define UDEVADM_SETTLE_TIMEOUT 10
@@ -39,7 +40,7 @@ pu_spawn_command_line_sync(const gchar *command_line,
         return FALSE;
     }
 
-    if (!g_spawn_check_exit_status(wait_status, error)) {
+    if (!g_spawn_check_wait_status(wait_status, error)) {
         g_prefix_error(error, "Command '%s' failed with error message: '%s': ",
                        command_line, errmsg);
         g_strfreev(argv);


### PR DESCRIPTION
Add a GLib compatibility header. Currently, this makes it possible to use g_spawn_check_wait_status() instead of its deprecated version g_spawn_check_exit_status() even in older, incompatible GLib versions.