### PR TITLE
Add option --dry-run

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -35,6 +35,7 @@ install [OPTION…] *PACKAGE* *DEVICE*
    Install a partup PACKAGE to DEVICE
 
    -s, --skip-checksums    Skip checksum verification for all input files
+   --dry-run               Do not write to device
 
 package [OPTION…] *PACKAGE* *FILES…*
    Create a partup PACKAGE with the contents FILES

--- a/src/pu-emmc.h
+++ b/src/pu-emmc.h
@@ -17,6 +17,7 @@ PuEmmc * pu_emmc_new(const gchar *device_path,
                      PuConfig *config,
                      const gchar *prefix,
                      gboolean skip_checksums,
+                     gboolean dry_run,
                      GError **error);
 
 #endif /* PARTUP_EMMC_H */

--- a/src/pu-flash.c
+++ b/src/pu-flash.c
@@ -11,6 +11,7 @@ typedef struct {
     PuConfig *config;
     gchar *prefix;
     gboolean skip_checksums;
+    gboolean dry_run;
 } PuFlashPrivate;
 
 enum {
@@ -19,6 +20,7 @@ enum {
     PROP_CONFIG,
     PROP_PREFIX,
     PROP_SKIP_CHECKSUMS,
+    PROP_DRY_RUN,
     NUM_PROPS
 };
 static GParamSpec *props[NUM_PROPS] = { NULL };
@@ -89,6 +91,9 @@ pu_flash_set_property(GObject *object,
     case PROP_SKIP_CHECKSUMS:
         priv->skip_checksums = g_value_get_boolean(value);
         break;
+    case PROP_DRY_RUN:
+        priv->dry_run = g_value_get_boolean(value);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
         break;
@@ -116,6 +121,9 @@ pu_flash_get_property(GObject *object,
         break;
     case PROP_SKIP_CHECKSUMS:
         g_value_set_boolean(value, priv->skip_checksums);
+        break;
+    case PROP_DRY_RUN:
+        g_value_set_boolean(value, priv->dry_run);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -157,6 +165,12 @@ pu_flash_class_init(PuFlashClass *class)
         g_param_spec_boolean("skip-checksums",
                              "Modifier to skip checksums",
                              "Modifier to skip checksum verification for all files when writing",
+                             FALSE,
+                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
+    props[PROP_DRY_RUN] =
+        g_param_spec_boolean("dry-run",
+                             "Do not write to device",
+                             "Do not write to device, only validate layout configuration and input files",
                              FALSE,
                              G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
 

--- a/src/pu-flash.c
+++ b/src/pu-flash.c
@@ -26,6 +26,16 @@ static GParamSpec *props[NUM_PROPS] = { NULL };
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(PuFlash, pu_flash, G_TYPE_OBJECT)
 
 static gboolean
+pu_flash_default_validate_config(PuFlash *self,
+                                 G_GNUC_UNUSED GError **error)
+{
+    g_critical("Flash of type '%s' does not implement PuFlash::validate_config",
+               G_OBJECT_TYPE_NAME(self));
+
+    return FALSE;
+}
+
+static gboolean
 pu_flash_default_init_device(PuFlash *self,
                              G_GNUC_UNUSED GError **error)
 {
@@ -118,6 +128,7 @@ pu_flash_class_init(PuFlashClass *class)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(class);
 
+    class->validate_config = pu_flash_default_validate_config;
     class->init_device = pu_flash_default_init_device;
     class->setup_layout = pu_flash_default_setup_layout;
     class->write_data = pu_flash_default_write_data;
@@ -155,6 +166,13 @@ pu_flash_class_init(PuFlashClass *class)
 static void
 pu_flash_init(G_GNUC_UNUSED PuFlash *self)
 {
+}
+
+gboolean
+pu_flash_validate_config(PuFlash *self,
+                         GError **error)
+{
+    return PU_FLASH_GET_CLASS(self)->validate_config(self, error);
 }
 
 gboolean

--- a/src/pu-flash.h
+++ b/src/pu-flash.h
@@ -21,16 +21,18 @@
  * PuFlash is the base object used for specific implementations of flash
  * devices. An example can be found for eMMC flash with PuEmmc.
  *
- * Implementations of PuFlash use three different functions representing the
- * different stages of initializing, formatting and writing a flash device. The
- * implementation of these functions are flash device specific and may vary
- * depending on its type.
+ * Implementations of PuFlash use four different functions representing the
+ * different stages of validating, initializing, formatting and writing a flash
+ * device. The implementation of these functions are flash device specific and
+ * may vary depending on its type.
  */
 G_DECLARE_DERIVABLE_TYPE(PuFlash, pu_flash, PU, FLASH, GObject)
 
 struct _PuFlashClass {
     GObjectClass parent_class;
 
+    gboolean (*validate_config)(PuFlash *self,
+                                GError **error);
     gboolean (*init_device)(PuFlash *self,
                             GError **error);
     gboolean (*setup_layout)(PuFlash *self,
@@ -40,6 +42,20 @@ struct _PuFlashClass {
 
     gpointer padding[8];
 };
+
+/**
+ * Validate the config for the flash device.
+ *
+ * Validate the config, e.g. check if input files exist and the checksum is
+ * correct.
+ *
+ * @param self the PuFlash instance.
+ * @param error a GError used for error handling.
+ *
+ * @return TRUE on success or FALSE if an error occurred.
+ */
+gboolean pu_flash_validate_config(PuFlash *self,
+                                  GError **error);
 
 /**
  * Initialize the flash device.

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -106,6 +106,10 @@ cmd_install(PuCommandContext *context,
         g_prefix_error(error, "Failed parsing eMMC info from config: ");
         return error_out(mount_path);
     }
+    if (!pu_flash_validate_config(PU_FLASH(emmc), error)) {
+        g_prefix_error(error, "Failed validating config:");
+        return 1;
+    }
     if (!pu_flash_init_device(PU_FLASH(emmc), error)) {
         g_prefix_error(error, "Failed initializing device: ");
         return error_out(mount_path);

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -19,6 +19,7 @@
 #include "pu-version.h"
 
 static gboolean arg_debug = FALSE;
+static gboolean arg_install_dry_run = FALSE;
 static gboolean arg_install_skip_checksums = FALSE;
 static gchar *arg_package_directory = NULL;
 static gboolean arg_package_force = FALSE;
@@ -101,7 +102,7 @@ cmd_install(PuCommandContext *context,
     }
 
     emmc = pu_emmc_new(device_path, config, mount_path,
-                       arg_install_skip_checksums, error);
+                       arg_install_skip_checksums, arg_install_dry_run, error);
     if (emmc == NULL) {
         g_prefix_error(error, "Failed parsing eMMC info from config: ");
         return error_out(mount_path);

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -185,6 +185,8 @@ static GOptionEntry option_entries_main[] = {
 static GOptionEntry option_entries_install[] = {
     { "skip-checksums", 's', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
         &arg_install_skip_checksums, "Skip checksum verification for all input files", NULL },
+    { "dry-run", 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
+        &arg_install_dry_run, "Do not write to device", NULL },
     { NULL }
 };
 

--- a/tests/emmc.c
+++ b/tests/emmc.c
@@ -31,7 +31,7 @@ emmc_simple(void)
     mmcblk0p1 = create_tmp_file("mmcblk0p1", path, 32 * PED_MEBIBYTE_SIZE, &error);
     mmcblk0p2 = create_tmp_file("mmcblk0p2", path, 64 * PED_MEBIBYTE_SIZE, &error);
 
-    emmc = pu_emmc_new(g_file_get_path(mmcblk0), config, NULL, FALSE, &error);
+    emmc = pu_emmc_new(g_file_get_path(mmcblk0), config, NULL, FALSE, FALSE, &error);
     g_assert_nonnull(emmc);
     g_assert_true(pu_flash_init_device(PU_FLASH(emmc), &error));
     g_assert_true(pu_flash_setup_layout(PU_FLASH(emmc), &error));


### PR DESCRIPTION
The option --dry-run disables writing to the device. Only the partitions and input files are validated. If the input files fit inside a partition is not checked.