### PR TITLE
Improve debug output

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -27,6 +27,7 @@ any command:
 
 -h, --help                 Show help options
 -d, --debug                Print debug messages
+-q, --quiet                Only print error messages
 
 Commands
 --------

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -25,9 +25,11 @@ Global Option List
 When executing partup, the following options can be specified independently of
 any command:
 
--h, --help                 Show help options
--d, --debug                Print debug messages
--q, --quiet                Only print error messages
+-h, --help                          Show help options
+-d, --debug                         Print debug messages
+-D, --debug-domains=DEBUG_DOMAINS   Comma separated list of modules to enable
+                                    debug output for
+-q, --quiet                         Only print error messages
 
 Commands
 --------

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ src = [
   'src/pu-flash.c',
   'src/pu-glib-compat.c',
   'src/pu-hashtable.c',
+  'src/pu-log.c',
   'src/pu-mount.c',
   'src/pu-package.c',
   'src/pu-utils.c'

--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,6 @@ src = [
 
 exec = executable(
   meson.project_name(),
-  c_args : ['-DG_LOG_DOMAIN="@0@"'.format(meson.project_name())],
   sources : [src, 'src/pu-main.c'],
   dependencies : deps,
   install : true

--- a/src/pu-config.c
+++ b/src/pu-config.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2022 PHYTEC Messtechnik GmbH
  */
 
+#define G_LOG_DOMAIN "partup-config"
+
 #include <glib.h>
 #include <gio/gio.h>
 #include <gmodule.h>

--- a/src/pu-emmc.c
+++ b/src/pu-emmc.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 PHYTEC Messtechnik GmbH
  */
 
+#define G_LOG_DOMAIN "partup-emmc"
+
 #include <parted/parted.h>
 #include <glib/gstdio.h>
 #include "pu-checksum.h"

--- a/src/pu-emmc.c
+++ b/src/pu-emmc.c
@@ -324,7 +324,6 @@ pu_emmc_write_data(PuFlash *flash,
             }
 
             if (g_regex_match_simple(".tar", path, G_REGEX_CASELESS, 0)) {
-                g_debug("Extracting '%s' to '%s'", path, part_mount);
                 if (!pu_mount(part_path, part_mount, NULL, NULL, error))
                     return FALSE;
                 if (!pu_archive_extract(path, part_mount, error))
@@ -332,13 +331,11 @@ pu_emmc_write_data(PuFlash *flash,
                 if (!pu_umount(part_mount, error))
                     return FALSE;
             } else if (g_regex_match_simple(".ext[234]$", path, 0, 0)) {
-                g_debug("Writing '%s' to '%s'", path, part_mount);
                 if (!pu_write_raw(path, part_path, self->device, 0, 0, 0, error))
                     return FALSE;
                 if (!pu_resize_filesystem(part_path, error))
                     return FALSE;
             } else {
-                g_debug("Copying '%s' to '%s'", path, part_mount);
                 if (!pu_mount(part_path, part_mount, NULL, NULL, error))
                     return FALSE;
                 if (!pu_file_copy(path, part_mount, error))

--- a/src/pu-emmc.c
+++ b/src/pu-emmc.c
@@ -254,8 +254,6 @@ pu_emmc_write_data(PuFlash *flash,
     g_autofree gchar *part_mount = NULL;
     g_autofree gchar *prefix = NULL;
 
-    g_debug(G_STRFUNC);
-
     g_return_val_if_fail(flash != NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
@@ -263,6 +261,8 @@ pu_emmc_write_data(PuFlash *flash,
                  "prefix", &prefix,
                  "skip-checksums", &skip_checksums,
                  NULL);
+
+    g_message("Writing data to partitions");
 
     for (GList *p = self->partitions; p != NULL; p = p->next) {
         PuEmmcPartition *part = p->data;
@@ -295,6 +295,8 @@ pu_emmc_write_data(PuFlash *flash,
             g_debug("No input specified. Skipping %s", part_path);
             continue;
         }
+
+        g_debug("Writing data to partition: %s", part_path);
 
         part_mount = pu_create_mount_point(g_strdup_printf("p%u", i), error);
         if (part_mount == NULL)
@@ -361,6 +363,8 @@ pu_emmc_write_data(PuFlash *flash,
         }
     }
 
+    g_message("Writing raw data to user area");
+
     for (GList *b = self->raw; b != NULL; b = b->next) {
         PuEmmcBinary *bin = b->data;
         PuEmmcInput *input = bin->input;
@@ -394,6 +398,8 @@ pu_emmc_write_data(PuFlash *flash,
                           bin->input_offset, bin->output_offset, 0, error))
             return FALSE;
     }
+
+    g_message("Writing to eMMC boot partitions");
 
     if (self->emmc_boot_partitions) {
         PuEmmcInput *input = self->emmc_boot_partitions->input;

--- a/src/pu-flash.c
+++ b/src/pu-flash.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2022 PHYTEC Messtechnik GmbH
  */
 
+#define G_LOG_DOMAIN "partup-flash"
+
 #include "pu-flash.h"
 #include "pu-config.h"
 

--- a/src/pu-log.c
+++ b/src/pu-log.c
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2023 PHYTEC Messtechnik GmbH
+ */
+
+#include <glib.h>
+#include "pu-log.h"
+
+GLogLevelFlags log_output_level;
+
+static GLogWriterOutput
+pu_log_writer(GLogLevelFlags log_level,
+              const GLogField *fields,
+              gsize n_fields,
+              gpointer user_data)
+{
+    if (log_level > log_output_level)
+        return G_LOG_WRITER_HANDLED;
+
+    return g_log_writer_standard_streams(log_level, fields, n_fields, user_data);
+}
+
+void
+pu_log_setup(gboolean quiet,
+             gboolean debug)
+{
+    g_autoptr(GString) new_domains = NULL;
+    const gchar *domains;
+
+    if (quiet) {
+        log_output_level = G_LOG_LEVEL_CRITICAL;
+    } else if (debug) {
+        domains = g_getenv("G_MESSAGES_DEBUG");
+
+        if (domains != NULL) {
+            g_string_printf(new_domains, "%s %s", domains, PU_LOG_DOMAINS);
+            g_setenv("G_MESSAGES_DEBUG", new_domains->str, TRUE);
+        } else {
+            g_setenv("G_MESSAGES_DEBUG", "partup", TRUE);
+        }
+        log_output_level = G_LOG_LEVEL_DEBUG;
+    } else {
+        log_output_level = G_LOG_LEVEL_INFO;
+    }
+
+    g_log_set_writer_func(pu_log_writer, NULL, NULL);
+}

--- a/src/pu-log.c
+++ b/src/pu-log.c
@@ -16,7 +16,16 @@ pu_log_writer(GLogLevelFlags log_level,
               gsize n_fields,
               gpointer user_data)
 {
-    if (log_level > log_output_level)
+    const gchar *log_domain = NULL;
+
+    for (gsize i = 0; i < n_fields; i++) {
+        if (g_strcmp0(fields[i].key, "GLIB_DOMAIN") == 0) {
+            log_domain = fields[i].value;
+            break;
+        }
+    }
+
+    if (log_level > log_output_level || g_log_writer_default_would_drop(log_level, log_domain))
         return G_LOG_WRITER_HANDLED;
 
     return g_log_writer_standard_streams(log_level, fields, n_fields, user_data);
@@ -24,14 +33,16 @@ pu_log_writer(GLogLevelFlags log_level,
 
 void
 pu_log_setup(gboolean quiet,
-             gboolean debug)
+             gboolean debug,
+             const gchar *debug_domains)
 {
     g_autoptr(GString) new_domains = NULL;
     const gchar *domains;
+    gchar **debug_arr;
 
     if (quiet) {
         log_output_level = G_LOG_LEVEL_CRITICAL;
-    } else if (debug) {
+    } else if (debug && !debug_domains) {
         domains = g_getenv("G_MESSAGES_DEBUG");
 
         if (domains != NULL) {
@@ -40,6 +51,16 @@ pu_log_setup(gboolean quiet,
         } else {
             g_setenv("G_MESSAGES_DEBUG", PU_LOG_DOMAINS, TRUE);
         }
+        log_output_level = G_LOG_LEVEL_DEBUG;
+    } else if (debug_domains) {
+        new_domains = g_string_new(g_getenv("G_MESSAGES_DEBUG"));
+        debug_arr = g_strsplit(debug_domains, ",", 0);
+        for (int i = 0; debug_arr[i] != NULL; i++) {
+            g_string_append(new_domains,
+                            g_strdup_printf("partup-%s", debug_arr[i]));
+        }
+        g_strfreev(debug_arr);
+        g_setenv("G_MESSAGES_DEBUG", new_domains->str, TRUE);
         log_output_level = G_LOG_LEVEL_DEBUG;
     } else {
         log_output_level = G_LOG_LEVEL_INFO;

--- a/src/pu-log.c
+++ b/src/pu-log.c
@@ -6,6 +6,8 @@
 #include <glib.h>
 #include "pu-log.h"
 
+#define PU_LOG_DOMAINS "partup partup-config partup-emmc partup-mount partup-utils"
+
 GLogLevelFlags log_output_level;
 
 static GLogWriterOutput
@@ -36,7 +38,7 @@ pu_log_setup(gboolean quiet,
             g_string_printf(new_domains, "%s %s", domains, PU_LOG_DOMAINS);
             g_setenv("G_MESSAGES_DEBUG", new_domains->str, TRUE);
         } else {
-            g_setenv("G_MESSAGES_DEBUG", "partup", TRUE);
+            g_setenv("G_MESSAGES_DEBUG", PU_LOG_DOMAINS, TRUE);
         }
         log_output_level = G_LOG_LEVEL_DEBUG;
     } else {

--- a/src/pu-log.h
+++ b/src/pu-log.h
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2023 PHYTEC Messtechnik GmbH
+ */
+
+#ifndef PARTUP_LOG_H
+#define PARTUP_LOG_H
+
+#include <glib.h>
+
+void pu_log_setup(gboolean quiet,
+                  gboolean debug);
+
+#endif /* PARTUP_LOG_H */

--- a/src/pu-log.h
+++ b/src/pu-log.h
@@ -9,6 +9,7 @@
 #include <glib.h>
 
 void pu_log_setup(gboolean quiet,
-                  gboolean debug);
+                  gboolean debug,
+                  const gchar *debug_domains);
 
 #endif /* PARTUP_LOG_H */

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -22,6 +22,7 @@
 #include "pu-version.h"
 
 static gboolean arg_debug = FALSE;
+static gchar *arg_debug_domains = NULL;
 static gboolean arg_quiet = FALSE;
 static gboolean arg_install_skip_checksums = FALSE;
 static gchar *arg_package_directory = NULL;
@@ -177,7 +178,10 @@ cmd_version(G_GNUC_UNUSED PuCommandContext *context,
 
 static GOptionEntry option_entries_main[] = {
     { "debug", 'd', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
-        &arg_debug, "Print debug messages", NULL },
+        &arg_debug, "Print debug messages for all modules", NULL },
+    { "debug-domains", 'D', G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING,
+        &arg_debug_domains, "Comma separated list of modules to enable debug output for",
+        "DEBUG_DOMAINS" },
     { "quiet", 'q', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
         &arg_quiet, "Only print error messages", NULL },
     { NULL }
@@ -237,7 +241,7 @@ main(G_GNUC_UNUSED int argc,
         return 1;
     }
 
-    pu_log_setup(arg_quiet, arg_debug);
+    pu_log_setup(arg_quiet, arg_debug, arg_debug_domains);
 
     if (!pu_command_context_invoke(context_cmd, &error)) {
         g_printerr("ERROR: %s\n", error->message);

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2022 PHYTEC Messtechnik GmbH
  */
 
+#define G_LOG_DOMAIN "partup"
+
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <locale.h>

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -13,12 +13,14 @@
 #include "pu-emmc.h"
 #include "pu-error.h"
 #include "pu-flash.h"
+#include "pu-log.h"
 #include "pu-mount.h"
 #include "pu-package.h"
 #include "pu-utils.h"
 #include "pu-version.h"
 
 static gboolean arg_debug = FALSE;
+static gboolean arg_quiet = FALSE;
 static gboolean arg_install_skip_checksums = FALSE;
 static gchar *arg_package_directory = NULL;
 static gboolean arg_package_force = FALSE;
@@ -174,6 +176,8 @@ cmd_version(G_GNUC_UNUSED PuCommandContext *context,
 static GOptionEntry option_entries_main[] = {
     { "debug", 'd', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
         &arg_debug, "Print debug messages", NULL },
+    { "quiet", 'q', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
+        &arg_quiet, "Only print error messages", NULL },
     { NULL }
 };
 
@@ -231,16 +235,7 @@ main(G_GNUC_UNUSED int argc,
         return 1;
     }
 
-    if (arg_debug) {
-        const gchar *domains = g_getenv("G_MESSAGES_DEBUG");
-
-        if (domains != NULL) {
-            g_autofree gchar *new_domains = g_strdup_printf("%s %s", domains, g_get_prgname());
-            g_setenv("G_MESSAGES_DEBUG", new_domains, TRUE);
-        } else {
-            g_setenv("G_MESSAGES_DEBUG", g_get_prgname(), TRUE);
-        }
-    }
+    pu_log_setup(arg_quiet, arg_debug);
 
     if (!pu_command_context_invoke(context_cmd, &error)) {
         g_printerr("ERROR: %s\n", error->message);

--- a/src/pu-mount.c
+++ b/src/pu-mount.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 PHYTEC Messtechnik GmbH
  */
 
+#define G_LOG_DOMAIN "partup-mount"
+
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <errno.h>

--- a/src/pu-mount.c
+++ b/src/pu-mount.c
@@ -69,6 +69,8 @@ pu_find_mounted(const gchar *device)
     }
     blkid_free_probe(pr);
 
+    g_debug("Device '%s' has %d partitions", device, num_partitions);
+
     tb = mnt_new_table();
     if (!tb)
         return NULL;
@@ -84,8 +86,10 @@ pu_find_mounted(const gchar *device)
             mnt_unref_table(tb);
             return NULL;
         }
-        if (mnt_table_find_source(tb, partname, MNT_ITER_FORWARD))
+        if (mnt_table_find_source(tb, partname, MNT_ITER_FORWARD)) {
+            g_debug("Partition '%s' is mounted", partname);
             g_ptr_array_add(mounted, g_steal_pointer(&partname));
+        }
     }
 
     mnt_unref_table(tb);
@@ -105,6 +109,8 @@ pu_mount(const gchar *source,
     g_return_val_if_fail(g_strcmp0(source, "") > 0, FALSE);
     g_return_val_if_fail(g_strcmp0(mount_point, "") > 0, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    g_debug("Mounting %s on %s", source, mount_point);
 
     ctx = mnt_new_context();
     if (!ctx) {
@@ -142,6 +148,8 @@ pu_umount(const gchar *mount_point,
 
     g_return_val_if_fail(g_strcmp0(mount_point, "") > 0, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    g_debug("Unmounting %s", mount_point);
 
     ctx = mnt_new_context();
     if (!ctx) {

--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -67,6 +67,8 @@ pu_file_copy(const gchar *src,
     g_return_val_if_fail(dest != NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
+    g_debug("Copying '%s' to '%s'", src, dest);
+
     in = g_file_new_for_path(src);
     out_path = g_build_filename(dest, g_path_get_basename(src), NULL);
     out = g_file_new_for_path(out_path);
@@ -84,6 +86,8 @@ pu_archive_extract(const gchar *filename,
     g_return_val_if_fail(filename != NULL, FALSE);
     g_return_val_if_fail(dest != NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    g_debug("Extracting '%s' to '%s'", filename, dest);
 
     cmd = g_strdup_printf("tar -xf %s -C %s", filename, dest);
 
@@ -178,6 +182,8 @@ pu_write_raw(const gchar *input_path,
     g_return_val_if_fail(input_path != NULL, FALSE);
     g_return_val_if_fail(output_path != NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    g_debug("Writing '%s' to '%s'", input_path, output_path);
 
     /* glib uses bytes not sectors */
     input_offset *= device->sector_size;

--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 PHYTEC Messtechnik GmbH
  */
 
+#define G_LOG_DOMAIN "partup-utils"
+
 #include <fcntl.h>
 #include <gio/gio.h>
 #include <glib.h>

--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -31,6 +31,8 @@ pu_spawn_command_line_sync(const gchar *command_line,
 
     g_return_val_if_fail(command_line != NULL, FALSE);
 
+    g_debug("Running command: %s", command_line);
+
     if (!g_shell_parse_argv(command_line, NULL, &argv, error))
         return FALSE;
 
@@ -145,6 +147,8 @@ pu_resize_filesystem(const gchar *part,
 
     g_return_val_if_fail(part != NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    g_debug("Resizing filesystem on: %s", part);
 
     cmd = g_strdup_printf("resize2fs %s", part);
 


### PR DESCRIPTION
Improve control over debug output with two new options:

--quiet: redirect all messages to the journal, except for error messages
--debug-domains: enable debug output only for the specified modules

Open points:
 - which messages should be debug or normal messages
 - add more debug output in `pu-utils` and `pu-mount`
 - disable compiler warnings for redefining `G_LOG_DOMAIN`

Supersedes #23 