### PR TITLE
Support for commands and new package format

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ The following tools and libraries must be installed on the target system for
 -  `libparted <https://www.gnu.org/software/parted/>`_
 -  `util-linux <https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git>`_
 -  `udev <https://git.kernel.org/pub/scm/linux/hotplug/udev.git>`_
+-  `squashfs-tools <https://github.com/plougher/squashfs-tools>`_
 
 For building *partup* from source and generating its documentation the following
 additional dependencies are needed:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -26,5 +26,6 @@ Main Features
 
    usage
    layout-config
+   package
    contributing
    changelog

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -18,6 +18,7 @@ if sphinx.found()
     'layout-config.rst',
     'layout-config-reference.rst',
     'layout-config-examples.rst',
+    'package.rst',
     'contributing.rst',
     'index.rst',
     'usage.rst',

--- a/doc/package.rst
+++ b/doc/package.rst
@@ -1,0 +1,42 @@
+Package Format
+==============
+
+partup packages use the `SquashFS filesystem
+<https://github.com/plougher/squashfs-tools>`__ to provide a read-only image
+containing all required input files and the :doc:`layout configuration file
+<layout-config-reference>`. The layout configuration file must be named
+``layout.yaml`` and be placed at the root of the package. When using partup's
+builtin command ``package`` to create one, these requirements are automatically
+checked against.
+
+Creating a package is as easy as specifying an output filename for the package,
+its input files and the layout configuration file named exactly
+``layout.yaml``::
+
+   partup package mypackage.partup u-boot.bin zImage rootfs.tar.gz layout.yaml
+
+.. note::
+
+   The first filename provided after the ``package`` command is always the
+   output filename of the package.
+
+.. note::
+
+   The extension of a partup package should be named ``.partup``, although this
+   is just a recommendation for easier distinction from other file types and is
+   not strictly needed.
+
+The content of a package can be listed using the ``show`` command::
+
+   partup show mypackage.partup
+
+   u-boot.bin
+   zImage
+   rootfs.tar.gz
+   layout.yaml
+
+A partup package contains all the information needed to install the initial data
+to a device. The ``install`` command then only needs the desired flash device to
+be specified::
+
+   partup install mypackage.partup /dev/mmcblk0

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -4,26 +4,51 @@ Usage
 General Usage
 -------------
 
-partup requires a configuration file specifying the layout and an output device
-to write to as its mandatory arguments. The full syntax is as follows::
+partup has different commands for executing all needed steps during the initial
+flashing process of a target device. The process is usually as follows:
 
-   partup [OPTION?] -c CONFIG DEVICE
+1. Create a partup package containing the layout configuration and any required
+   input files.
+2. Install this partup package to the device.
 
-An minimal example may look like the following::
+partup also provides a command for displaying the contents of a partup package.
+For a detailed description on how these packages work and how to create them,
+see the page :doc:`package`.
 
-   partup -c layout.yaml /dev/mmcblk2
+The general usage syntax looks like the following::
 
-Option List
------------
+   partup [OPTION…] COMMAND ARGUMENTS
 
-When executing partup, the following options can be specified:
+Global Option List
+------------------
 
--h, --help              Show help options
--c, --config=CONFIG     Layout configuration file in YAML format
--d, --debug             Print debug messages
--p, --prefix=PREFIX     Path to prefix all file URIs with in the layout configuration
--s, --skip-checksums    Skip checksum verification for all input files
--v, --version           Print the program version and exit
+When executing partup, the following options can be specified independently of
+any command:
+
+-h, --help                 Show help options
+-d, --debug                Print debug messages
+
+Commands
+--------
+
+install [OPTION…] *PACKAGE* *DEVICE*
+   Install a partup PACKAGE to DEVICE
+
+   -s, --skip-checksums    Skip checksum verification for all input files
+
+package [OPTION…] *PACKAGE* *FILES…*
+   Create a partup PACKAGE with the contents FILES
+
+   -C, --directory=DIR     Change to DIR before creating the package
+   -f, --force             Overwrite any existing package
+
+show [OPTION…] *PACKAGE*
+   List the contents of a partup PACKAGE
+
+   -s, --size              Print the size of each file
+
+version
+   Print the program version
 
 Supported Output Devices
 ------------------------

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,7 @@ src = [
   'src/pu-emmc.c',
   'src/pu-error.c',
   'src/pu-flash.c',
+  'src/pu-glib-compat.c',
   'src/pu-hashtable.c',
   'src/pu-mount.c',
   'src/pu-utils.c'

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ src = [
   'src/pu-glib-compat.c',
   'src/pu-hashtable.c',
   'src/pu-mount.c',
+  'src/pu-package.c',
   'src/pu-utils.c'
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,7 @@ deps = [
 ]
 src = [
   'src/pu-checksum.c',
+  'src/pu-command.c',
   'src/pu-config.c',
   'src/pu-emmc.c',
   'src/pu-error.c',

--- a/src/pu-command.c
+++ b/src/pu-command.c
@@ -1,0 +1,340 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2023 PHYTEC Messtechnik GmbH
+ */
+
+#include "pu-glib-compat.h"
+#include "pu-command.h"
+
+struct _PuCommandContext {
+    /* The currently used command and options for this context */
+    PuCommandEntry *command;
+    /* Additional arguments (null-terminated), not being commands or options */
+    gchar **args;
+
+    /* The option context to append options to */
+    GOptionContext *option_context;
+
+    /* Command description appended to the option context */
+    gchar *description;
+
+    /* All valid command entries */
+    PuCommandEntry *entries;
+    gsize entries_len;
+};
+
+G_DEFINE_QUARK(pu-command-context-error-quark, pu_command_error)
+
+PuCommandContext *
+pu_command_context_new(void)
+{
+    PuCommandContext *context;
+
+    context = g_new0(PuCommandContext, 1);
+    context->option_context = g_option_context_new("COMMAND");
+
+    return context;
+}
+
+void
+pu_command_context_free(PuCommandContext *context)
+{
+    g_return_if_fail(context != NULL);
+
+    context->command = NULL;
+    g_strfreev(context->args);
+
+    g_free(context->description);
+    g_free(context->entries);
+
+    if (context->option_context)
+        g_option_context_free(context->option_context);
+
+    g_free(context);
+}
+
+static gint
+pu_unichar_get_width(gunichar c)
+{
+    if (G_UNLIKELY(g_unichar_iszerowidth(c)))
+        return 0;
+
+    if (g_unichar_iswide(c))
+        return 2;
+
+    return 1;
+}
+
+static gint
+pu_utf8_strlen(const gchar *s)
+{
+    gint len = 0;
+
+    g_return_val_if_fail(s != NULL, 0);
+
+    while (*s) {
+        len += pu_unichar_get_width(g_utf8_get_char(s));
+        s = g_utf8_next_char(s);
+    }
+
+    return len;
+}
+
+static gchar *
+get_main_help(PuCommandContext *context)
+{
+    GString *string = NULL;
+    GString *entry_string = NULL;
+    PuCommandEntry *entry = NULL;
+    g_autofree gchar *orig_help = NULL;
+    g_autoptr(GRegex) regex = NULL;
+    g_autoptr(GMatchInfo) match_info = NULL;
+    g_autoptr(GString) match_string = NULL;
+    gsize max_len = 0;
+
+    g_return_val_if_fail(context != NULL, NULL);
+
+    /* Get help text of option context */
+    orig_help = g_option_context_get_help(context->option_context, TRUE, NULL);
+    string = g_string_new(NULL);
+
+    /* Search original help text for length of options including whitespace */
+    regex = g_regex_new("  -h, --help\\s+", 0, 0, NULL);
+    g_regex_match(regex, orig_help, 0, &match_info);
+    if (g_match_info_matches(match_info)) {
+        match_string = g_string_new(g_match_info_fetch(match_info, 0));
+        max_len = match_string->len;
+    } else {
+        max_len = 6 + pu_utf8_strlen(context->entries[0].name);
+    }
+
+    /* Construct command help text */
+    g_string_append(string, "Commands:\n");
+    for (gsize i = 0; i < context->entries_len; i++) {
+        entry = &context->entries[i];
+        entry_string = g_string_new(NULL);
+
+        g_string_append_printf(entry_string, "  %s", entry->name);
+        g_string_append_printf(entry_string, "%*s%s\n",
+                               (gint) (max_len - pu_utf8_strlen(entry_string->str)), "",
+                               entry->description ? entry->description : "");
+        g_string_append(string, g_string_free_and_steal(entry_string));
+    }
+
+    g_string_append_printf(string,
+                           "\nExecute any command with the '-h, --help' option "
+                           "to show command specific help.");
+
+    return g_string_free_and_steal(string);
+}
+
+static const gchar *
+get_command_help(PuCommandContext *context,
+                 const gchar *command)
+{
+    PuCommandEntry *entry = NULL;
+
+    g_return_val_if_fail(context != NULL, NULL);
+    g_return_val_if_fail(command != NULL, NULL);
+
+    /* Find command in list of valid command entries */
+    for (gsize i = 0; i < context->entries_len; i++) {
+        if (g_str_equal(command, context->entries[i].name)) {
+            entry = &context->entries[i];
+            break;
+        }
+    }
+
+    if (!entry)
+        return NULL;
+
+    return entry->description;
+}
+
+static gchar *
+get_help_text(PuCommandContext *context,
+              const gchar *command)
+{
+    GString *string = NULL;
+
+    g_return_val_if_fail(context != NULL, NULL);
+
+    string = g_string_new(NULL);
+
+    if (command)
+        g_string_append(string, get_command_help(context, command));
+    else
+        g_string_append(string, get_main_help(context));
+
+    g_string_append(string,
+                    "\n\nDocumentation: <https://phytec.github.io/partup>\n"
+                    "Report any issues at: <https://github.com/phytec/partup/issues>");
+
+    return g_string_free_and_steal(string);
+}
+
+void
+pu_command_context_add_entries(PuCommandContext *context,
+                               const PuCommandEntry *entries,
+                               const GOptionEntry *main_option_entries)
+{
+    gsize entries_len;
+
+    g_return_if_fail(context != NULL);
+    g_return_if_fail(entries != NULL);
+
+    if (main_option_entries) {
+        g_option_context_add_main_entries(context->option_context,
+                                          main_option_entries, NULL);
+    } else {
+        GOptionEntry entries[] = { { NULL } };
+        g_option_context_add_main_entries(context->option_context, entries, NULL);
+    }
+
+    for (entries_len = 0; entries[entries_len].name != NULL; entries_len++);
+    g_return_if_fail(entries_len <= G_MAXSIZE - context->entries_len);
+
+    context->entries = g_renew(PuCommandEntry, context->entries,
+                               context->entries_len + entries_len);
+
+    if (entries_len != 0) {
+        memcpy(context->entries + context->entries_len, entries,
+               sizeof(PuCommandEntry) * entries_len);
+    }
+
+    context->entries_len += entries_len;
+}
+
+gchar *
+pu_command_context_get_help(PuCommandContext *context,
+                            const gchar *command)
+{
+    g_option_context_set_description(context->option_context,
+                                     get_help_text(context, command));
+
+    return g_option_context_get_help(context->option_context, TRUE, NULL);
+}
+
+gchar **
+pu_command_context_get_args(PuCommandContext *context)
+{
+    g_return_val_if_fail(context != NULL, FALSE);
+    g_return_val_if_fail(context->command != NULL, FALSE);
+    g_return_val_if_fail(context->args != NULL, FALSE);
+
+    return context->args;
+}
+
+gboolean
+pu_command_context_parse(PuCommandContext *context,
+                         gint *argc,
+                         gchar ***argv,
+                         GError **error)
+{
+    g_return_val_if_fail(context != NULL, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    if (!argc || !argv) {
+        g_set_error(error, PU_COMMAND_ERROR, PU_COMMAND_ERROR_BAD_VALUE,
+                    "No command provided");
+        return FALSE;
+    }
+
+    /* Search argv for a valid command */
+    for (gsize i = 0; i < context->entries_len; i++) {
+        if (g_strv_contains((const gchar * const *) *argv, context->entries[i].name)) {
+            context->command = &context->entries[i];
+            context->command->option_entries = context->entries[i].option_entries;
+            break;
+        }
+    }
+
+    if (!context->command &&
+        !(g_strv_contains((const gchar * const *) *argv, "-h") ||
+          g_strv_contains((const gchar * const *) *argv, "--help"))) {
+        g_set_error(error, PU_COMMAND_ERROR, PU_COMMAND_ERROR_UNKNOWN_COMMAND,
+                    "Invalid command '%s'", (*argv)[1]);
+        return FALSE;
+    }
+
+    /* Set appropriate help text */
+    if (context->command) {
+        g_option_context_set_description(context->option_context,
+                                         get_help_text(context, context->command->name));
+    } else {
+        g_option_context_set_description(context->option_context,
+                                         get_help_text(context, NULL));
+    }
+
+    /* Add command-specific options */
+    if (context->command && context->command->option_entries != NULL) {
+        g_option_context_add_main_entries(context->option_context,
+                                          context->command->option_entries, NULL);
+    }
+
+    /* Parse main options and command-specific ones */
+    if (!g_option_context_parse(context->option_context, argc, argv, error)) {
+        g_prefix_error(error, "Failed parsing options: ");
+        return FALSE;
+    }
+
+    /* Consume first argument (program name) and second one (command name) and
+     * update argv accordingly */
+    for (gint i = 0; i < *argc - 2; i++) {
+        g_free((*argv)[i]);
+        (*argv)[i] = g_strdup((*argv)[i + 2]);
+    }
+    for (gint i = 0; i < 2; i++) {
+        g_free((*argv)[*argc - 1]);
+        (*argv)[*argc - 1] = NULL;
+        (*argc)--;
+    }
+
+    /* Check for correct number of arguments depending on command type */
+    if ((*argc != 0 && context->command->arg == PU_COMMAND_ARG_NONE) ||
+        (*argc != 1 && context->command->arg == PU_COMMAND_ARG_FILENAME) ||
+        (*argc < 2 && context->command->arg == PU_COMMAND_ARG_FILENAME_ARRAY)) {
+        g_autofree gchar *excess_args = g_strjoinv(" ", *argv + 1);
+        g_set_error(error, PU_COMMAND_ERROR, PU_COMMAND_ERROR_BAD_VALUE,
+                    "Invalid number of arguments for command '%s'",
+                    context->command->name);
+        return FALSE;
+    }
+
+    context->args = g_strdupv(*argv);
+
+    return TRUE;
+}
+
+gboolean
+pu_command_context_parse_strv(PuCommandContext *context,
+                              gchar ***args,
+                              GError **error)
+{
+    gboolean res;
+    gint argc;
+
+    g_return_val_if_fail(context != NULL, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    argc = args && *args ? g_strv_length(*args) : 0;
+    res = pu_command_context_parse(context, &argc, args, error);
+
+    return res;
+}
+
+gboolean
+pu_command_context_invoke(PuCommandContext *context,
+                          GError **error)
+{
+    g_return_val_if_fail(context != NULL, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    if (!context->command) {
+        g_set_error(error, PU_COMMAND_ERROR, PU_COMMAND_ERROR_UNKNOWN_COMMAND,
+                    "No command parsed yet");
+        return FALSE;
+    }
+
+    return context->command->func(context, error);
+}

--- a/src/pu-command.h
+++ b/src/pu-command.h
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2023 PHYTEC Messtechnik GmbH
+ */
+
+#ifndef PARTUP_COMMAND_H
+#define PARTUP_COMMAND_H
+
+#include <glib.h>
+
+#define PU_COMMAND_ERROR (pu_command_error_quark())
+
+GQuark pu_command_error_quark(void);
+
+typedef enum {
+    PU_COMMAND_ERROR_UNKNOWN_COMMAND,
+    PU_COMMAND_ERROR_BAD_VALUE,
+    PU_COMMAND_ERROR_FAILED
+} PuCommandError;
+
+typedef struct _PuCommandContext PuCommandContext;
+typedef struct _PuCommandEntry PuCommandEntry;
+
+typedef gboolean (*PuCommandFunc)(PuCommandContext *context,
+                                  GError **error);
+
+typedef enum {
+    PU_COMMAND_ARG_NONE,
+    PU_COMMAND_ARG_FILENAME,
+    PU_COMMAND_ARG_FILENAME_ARRAY
+} PuCommandArg;
+
+struct _PuCommandEntry {
+    const gchar *name;
+    PuCommandArg arg;
+    PuCommandFunc func;
+    const gchar *description;
+    const GOptionEntry *option_entries;
+};
+
+#define PU_COMMAND_ENTRY_NULL \
+    { NULL, 0, NULL, NULL, NULL }
+
+PuCommandContext * pu_command_context_new(void);
+void pu_command_context_free(PuCommandContext *context);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(PuCommandContext, pu_command_context_free)
+void pu_command_context_add_entries(PuCommandContext *context,
+                                    const PuCommandEntry *entries,
+                                    const GOptionEntry *main_option_entries);
+gchar * pu_command_context_get_help(PuCommandContext *context,
+                                    const gchar *command);
+gchar ** pu_command_context_get_args(PuCommandContext *context);
+gboolean pu_command_context_parse(PuCommandContext *context,
+                                  gint *argc,
+                                  gchar ***argv,
+                                  GError **error);
+gboolean pu_command_context_parse_strv(PuCommandContext *context,
+                                       gchar ***args,
+                                       GError **error);
+gboolean pu_command_context_invoke(PuCommandContext *context,
+                                   GError **error);
+
+#endif /* PARTUP_COMMAND_H */

--- a/src/pu-emmc.c
+++ b/src/pu-emmc.c
@@ -320,7 +320,7 @@ pu_emmc_write_data(PuFlash *flash,
 
             if (g_regex_match_simple(".tar", path, G_REGEX_CASELESS, 0)) {
                 g_debug("Extracting '%s' to '%s'", path, part_mount);
-                if (!pu_mount(part_path, part_mount, error))
+                if (!pu_mount(part_path, part_mount, NULL, NULL, error))
                     return FALSE;
                 if (!pu_archive_extract(path, part_mount, error))
                     return FALSE;
@@ -334,7 +334,7 @@ pu_emmc_write_data(PuFlash *flash,
                     return FALSE;
             } else {
                 g_debug("Copying '%s' to '%s'", path, part_mount);
-                if (!pu_mount(part_path, part_mount, error))
+                if (!pu_mount(part_path, part_mount, NULL, NULL, error))
                     return FALSE;
                 if (!pu_file_copy(path, part_mount, error))
                     return FALSE;

--- a/src/pu-glib-compat.c
+++ b/src/pu-glib-compat.c
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2023 PHYTEC Messtechnik GmbH
+ */
+
+#include "pu-glib-compat.h"
+
+#if !GLIB_CHECK_VERSION(2, 76, 0)
+gchar *
+g_string_free_and_steal(GString *string)
+{
+    return g_string_free(string, FALSE);
+}
+#endif

--- a/src/pu-glib-compat.h
+++ b/src/pu-glib-compat.h
@@ -12,4 +12,8 @@
 #define g_spawn_check_wait_status g_spawn_check_exit_status
 #endif
 
+#if !GLIB_CHECK_VERSION(2, 76, 0)
+gchar * g_string_free_and_steal(GString *string) G_GNUC_WARN_UNUSED_RESULT;
+#endif
+
 #endif /* PU_GLIB_COMPAT_H */

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -218,7 +218,6 @@ main(G_GNUC_UNUSED int argc,
     g_autofree gchar **args;
     g_autofree gchar *default_cmd = NULL;
     g_autofree gchar **main_args = NULL;
-    const gchar *prog_name = g_path_get_basename(argv[0]);
 
     /* Support unicode filenames */
     args = g_strdupv(argv);
@@ -234,10 +233,10 @@ main(G_GNUC_UNUSED int argc,
         const gchar *domains = g_getenv("G_MESSAGES_DEBUG");
 
         if (domains != NULL) {
-            g_autofree gchar *new_domains = g_strdup_printf("%s %s", domains, prog_name);
+            g_autofree gchar *new_domains = g_strdup_printf("%s %s", domains, g_get_prgname());
             g_setenv("G_MESSAGES_DEBUG", new_domains, TRUE);
         } else {
-            g_setenv("G_MESSAGES_DEBUG", prog_name, TRUE);
+            g_setenv("G_MESSAGES_DEBUG", g_get_prgname(), TRUE);
         }
     }
 

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -5,6 +5,7 @@
 
 #include <glib.h>
 #include <glib/gstdio.h>
+#include <locale.h>
 #include <parted/parted.h>
 #include <unistd.h>
 #include "pu-command.h"
@@ -220,6 +221,7 @@ main(G_GNUC_UNUSED int argc,
     g_autofree gchar **main_args = NULL;
 
     /* Support unicode filenames */
+    setlocale(LC_ALL, "");
     args = g_strdupv(argv);
 
     context_cmd = pu_command_context_new();

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -7,54 +7,205 @@
 #include <glib/gstdio.h>
 #include <parted/parted.h>
 #include <unistd.h>
+#include "pu-command.h"
 #include "pu-config.h"
 #include "pu-emmc.h"
+#include "pu-error.h"
 #include "pu-flash.h"
 #include "pu-mount.h"
+#include "pu-package.h"
 #include "pu-utils.h"
 #include "pu-version.h"
 
 static gboolean arg_debug = FALSE;
-static gboolean arg_version = FALSE;
-static gboolean arg_skip_checksums = FALSE;
-static gchar *arg_config = NULL;
-static gchar *arg_device = NULL;
-static gchar *arg_prefix = NULL;
+static gboolean arg_install_skip_checksums = FALSE;
+static gchar *arg_package_directory = NULL;
+static gboolean arg_package_force = FALSE;
+static gboolean arg_show_size = FALSE;
+
+static inline gboolean
+error_not_root(GError **error)
+{
+    g_set_error(error, PU_ERROR, PU_ERROR_FAILED,
+                "%s must be run as root", g_get_prgname());
+    return FALSE;
+}
+
+static inline gboolean
+error_out(const gchar *mountpoint)
+{
+    pu_package_umount(mountpoint, NULL);
+    return FALSE;
+}
 
 static gboolean
-arg_parse_remaining(const gchar *option_name,
-                    const gchar *value,
-                    G_GNUC_UNUSED gpointer data,
-                    GError **error)
+cmd_install(PuCommandContext *context,
+            GError **error)
 {
-    g_debug("%s(option_name=\"%s\" value=\"%s\")", __func__, option_name, value);
+    g_autoptr(PuConfig) config = NULL;
+    g_autofree gchar *mount_path = NULL;
+    g_autofree gchar *config_path = NULL;
+    g_autofree gchar *package_path = NULL;
+    g_autofree gchar *device_path = NULL;
+    g_autoptr(PuEmmc) emmc = NULL;
+    gchar **args;
+    gint api_version;
+    gboolean is_mounted;
 
-    if (arg_device == NULL) {
-        arg_device = g_strdup(value);
-    } else {
-        g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
-                    "%s", "Excess values in remaining arguments!");
+    if (getuid() != 0)
+        return error_not_root(error);
+
+    args = pu_command_context_get_args(context);
+    package_path = g_strdup(args[0]);
+    device_path = g_strdup(args[1]);
+
+    if (args[2]) {
+        g_set_error(error, PU_ERROR, PU_ERROR_FAILED,
+                    "Too many arguments");
         return FALSE;
     }
+
+    if (!pu_is_drive(device_path)) {
+        g_set_error(error, PU_ERROR, PU_ERROR_FAILED,
+                    "Device '%s' is not a drive", device_path);
+        return FALSE;
+    }
+
+    if (!pu_device_mounted(device_path, &is_mounted, error)) {
+        g_prefix_error(error, "Failed checking if device is in use: ");
+        return FALSE;
+    }
+
+    if (is_mounted) {
+        g_set_error(error, PU_ERROR, PU_ERROR_FAILED,
+                    "Device '%s' is in use", device_path);
+        return FALSE;
+    }
+
+    if (!pu_package_mount(package_path, &mount_path, &config_path, error))
+        return FALSE;
+
+    config = pu_config_new_from_file(config_path, error);
+    if (config == NULL) {
+        g_prefix_error(error, "Failed creating configuration object for file '%s': ",
+                       config_path);
+        return error_out(mount_path);
+    }
+    api_version = pu_config_get_api_version(config);
+    if (api_version > PARTUP_VERSION_MAJOR) {
+        g_set_error(error, PU_ERROR, PU_ERROR_FAILED,
+                    "API version %d of configuration file is not compatible "
+                    "with program version %d", api_version, PARTUP_VERSION_MAJOR);
+        return error_out(mount_path);
+    }
+
+    emmc = pu_emmc_new(device_path, config, mount_path,
+                       arg_install_skip_checksums, error);
+    if (emmc == NULL) {
+        g_prefix_error(error, "Failed parsing eMMC info from config: ");
+        return error_out(mount_path);
+    }
+    if (!pu_flash_init_device(PU_FLASH(emmc), error)) {
+        g_prefix_error(error, "Failed initializing device: ");
+        return error_out(mount_path);
+    }
+    if (!pu_flash_setup_layout(PU_FLASH(emmc), error)) {
+        g_prefix_error(error, "Failed setting up layout on device: ");
+        return error_out(mount_path);
+    }
+    if (!pu_flash_write_data(PU_FLASH(emmc), error)) {
+        g_prefix_error(error, "Failed writing data to device: ");
+        pu_umount_all(device_path, NULL);
+        return error_out(mount_path);
+    }
+
+    return pu_package_umount(mount_path, error);
+}
+
+static gboolean
+cmd_package(PuCommandContext *context,
+            GError **error)
+{
+    g_autofree gchar *package = NULL;
+    gchar **args;
+
+    args = pu_command_context_get_args(context);
+
+    if (!g_path_is_absolute(args[0]) && arg_package_directory)
+        package = g_build_filename(g_get_current_dir(), args[0], NULL);
+    else
+        package = g_strdup(args[0]);
+
+    if (arg_package_directory) {
+        if (g_chdir(arg_package_directory) < 0) {
+            g_set_error(error, PU_ERROR, PU_ERROR_FAILED,
+                        "Cannot change to directory '%s'", arg_package_directory);
+            return FALSE;
+        }
+    }
+
+    return pu_package_create(&args[1], package, arg_package_force, error);
+}
+
+static gboolean
+cmd_show(PuCommandContext *context,
+         GError **error)
+{
+    gchar **args;
+
+    if (getuid() != 0)
+        return error_not_root(error);
+
+    args = pu_command_context_get_args(context);
+
+    return pu_package_list_contents(args[0], arg_show_size, error);
+}
+
+static gboolean
+cmd_version(G_GNUC_UNUSED PuCommandContext *context,
+            G_GNUC_UNUSED GError **error)
+{
+    g_print("%s %s\n", g_get_prgname(), PARTUP_VERSION_STRING);
 
     return TRUE;
 }
 
-static GOptionEntry option_entries[] = {
-    { "config", 'c', G_OPTION_FLAG_NONE, G_OPTION_ARG_FILENAME,
-        &arg_config, "Layout configuration file in YAML format", "CONFIG" },
+static GOptionEntry option_entries_main[] = {
     { "debug", 'd', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
         &arg_debug, "Print debug messages", NULL },
-    { "prefix", 'p', G_OPTION_FLAG_NONE, G_OPTION_ARG_FILENAME,
-        &arg_prefix, "Path to prefix all file URIs with in the layout configuration",
-        "PREFIX" },
-    { "skip-checksums", 's', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
-        &arg_skip_checksums, "Skip checksum verification for all input files", NULL },
-    { "version", 'v', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
-        &arg_version, "Print the program version and exit", NULL },
-    { G_OPTION_REMAINING, 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_CALLBACK,
-        arg_parse_remaining, NULL, NULL },
     { NULL }
+};
+
+static GOptionEntry option_entries_install[] = {
+    { "skip-checksums", 's', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
+        &arg_install_skip_checksums, "Skip checksum verification for all input files", NULL },
+    { NULL }
+};
+
+static GOptionEntry option_entries_package[] = {
+    { "directory", 'C', G_OPTION_FLAG_NONE, G_OPTION_ARG_FILENAME,
+        &arg_package_directory, "Change to DIR before creating the package", "DIR" },
+    { "force", 'f', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
+        &arg_package_force, "Overwrite any existing package", NULL },
+    { NULL }
+};
+
+static GOptionEntry option_entries_show[] = {
+    { "size", 's', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
+        &arg_show_size, "Print the size of each file", NULL },
+    { NULL }
+};
+
+static PuCommandEntry command_entries[] = {
+    { "install", PU_COMMAND_ARG_FILENAME_ARRAY, cmd_install,
+        "Install a package to a device", option_entries_install },
+    { "package", PU_COMMAND_ARG_FILENAME_ARRAY, cmd_package,
+        "Create a package from files", option_entries_package },
+    { "show", PU_COMMAND_ARG_FILENAME, cmd_show,
+        "List the contents of a package", option_entries_show },
+    { "version", PU_COMMAND_ARG_NONE, cmd_version,
+        "Print the program version", NULL },
+    PU_COMMAND_ENTRY_NULL
 };
 
 int
@@ -62,23 +213,20 @@ main(G_GNUC_UNUSED int argc,
      char **argv)
 {
     g_autoptr(GError) error = NULL;
-    g_autoptr(GOptionContext) context = NULL;
-    g_autoptr(PuConfig) config = NULL;
-    g_autoptr(PuEmmc) emmc = NULL;
+    g_autoptr(PuCommandContext) context_cmd = NULL;
+    g_autoptr(GOptionContext) option_context = NULL;
     g_autofree gchar **args;
-    gboolean is_mounted;
-    gint api_version;
+    g_autofree gchar *default_cmd = NULL;
+    g_autofree gchar **main_args = NULL;
     const gchar *prog_name = g_path_get_basename(argv[0]);
 
     /* Support unicode filenames */
     args = g_strdupv(argv);
 
-    context = g_option_context_new("-c CONFIG DEVICE");
-    g_option_context_add_main_entries(context, option_entries, NULL);
-    g_option_context_set_description(context, "Report any issues at "
-                                     "<https://github.com/phytec/partup>");
-    if (!g_option_context_parse_strv(context, &args, &error)) {
-        g_printerr("Failed parsing options: %s\n", error->message);
+    context_cmd = pu_command_context_new();
+    pu_command_context_add_entries(context_cmd, command_entries, option_entries_main);
+    if (!pu_command_context_parse_strv(context_cmd, &args, &error)) {
+        g_printerr("ERROR: %s\n", error->message);
         return 1;
     }
 
@@ -93,80 +241,10 @@ main(G_GNUC_UNUSED int argc,
         }
     }
 
-    if (arg_version) {
-        g_print("%s %s\n", prog_name, PARTUP_VERSION_STRING);
-        return 0;
-    }
-
-    if (getuid() != 0) {
-        g_printerr("%s must be run as root!\n", prog_name);
+    if (!pu_command_context_invoke(context_cmd, &error)) {
+        g_printerr("ERROR: %s\n", error->message);
         return 1;
     }
-
-    if (g_strcmp0(arg_config, "") <= 0 || g_strcmp0(arg_device, "") <= 0) {
-        g_printerr("Not enough arguments!\n");
-        g_print("%s", g_option_context_get_help(context, TRUE, NULL));
-        return 1;
-    }
-
-    if (!pu_is_drive(arg_device)) {
-        g_printerr("Device '%s' is not a drive!\n", arg_device);
-        return 1;
-    }
-
-    if (!pu_device_mounted(arg_device, &is_mounted, &error)) {
-        g_printerr("Failed checking if device is in use: %s\n", error->message);
-        return 1;
-    }
-
-    if (is_mounted) {
-        g_printerr("Device '%s' is in use!\n", arg_device);
-        return 1;
-    }
-
-    if (!g_str_has_suffix(arg_config, ".yaml") &&
-        !g_str_has_suffix(arg_config, ".yml")) {
-        g_printerr("Configuration file does not seem to be a YAML file!\n");
-        return 1;
-    }
-
-    config = pu_config_new_from_file(arg_config, &error);
-    if (config == NULL) {
-        g_printerr("Failed creating configuration object for file '%s': %s\n",
-                   arg_config, error->message);
-        return 1;
-    }
-    api_version = pu_config_get_api_version(config);
-    if (api_version > PARTUP_VERSION_MAJOR) {
-        g_printerr("API version %d of configuration file is not compatible "
-                   "with program version %d!\n", api_version, PARTUP_VERSION_MAJOR);
-        return 1;
-    }
-
-    emmc = pu_emmc_new(arg_device, config, arg_prefix, arg_skip_checksums, &error);
-    if (emmc == NULL) {
-        g_printerr("Failed parsing eMMC info from config: %s\n", error->message);
-        return 1;
-    }
-    if (!pu_flash_init_device(PU_FLASH(emmc), &error)) {
-        g_printerr("Failed initializing device: %s\n", error->message);
-        return 1;
-    }
-    if (!pu_flash_setup_layout(PU_FLASH(emmc), &error)) {
-        g_printerr("Failed setting up layout on device: %s\n", error->message);
-        return 1;
-    }
-    if (!pu_flash_write_data(PU_FLASH(emmc), &error)) {
-        g_printerr("Failed writing data to device: %s\n", error->message);
-        g_clear_error(&error);
-        if (!pu_umount_all(arg_device, &error))
-            g_printerr("Failed unmounting partitions being used by %s: %s\n",
-                       prog_name, error->message);
-        return 1;
-    }
-
-    g_free(arg_config);
-    g_free(arg_device);
 
     return 0;
 }

--- a/src/pu-mount.c
+++ b/src/pu-mount.c
@@ -93,6 +93,8 @@ pu_find_mounted(const gchar *device)
 gboolean
 pu_mount(const gchar *source,
          const gchar *mount_point,
+         const gchar *type,
+         const gchar *options,
          GError **error)
 {
     gint ret;
@@ -109,8 +111,14 @@ pu_mount(const gchar *source,
                     source, mount_point);
         return FALSE;
     }
+
     mnt_context_set_target(ctx, mount_point);
     mnt_context_set_source(ctx, source);
+    if (g_strcmp0(type, "") > 0)
+        mnt_context_set_fstype_pattern(ctx, type);
+    if (g_strcmp0(options, "") > 0)
+        mnt_context_append_options(ctx, options);
+
     ret = mnt_context_mount(ctx);
     if (ret || mnt_context_get_status(ctx) != 1) {
         g_set_error(error, PU_ERROR, PU_ERROR_MOUNT,

--- a/src/pu-mount.h
+++ b/src/pu-mount.h
@@ -14,6 +14,8 @@ gchar * pu_create_mount_point(const gchar *name,
                               GError **error);
 gboolean pu_mount(const gchar *source,
                   const gchar *mount_point,
+                  const gchar *type,
+                  const gchar *options,
                   GError **error);
 gboolean pu_umount(const gchar *mount_point,
                    GError **error);

--- a/src/pu-package.c
+++ b/src/pu-package.c
@@ -1,0 +1,236 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2023 PHYTEC Messtechnik GmbH
+ */
+
+#include <fcntl.h>
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include "pu-error.h"
+#include "pu-package.h"
+#include "pu-utils.h"
+
+G_DEFINE_QUARK(pu-package-context-error-quark, pu_package_error)
+
+gchar *
+pu_package_get_layout_file(const gchar *pwd,
+                           GError **error)
+{
+    g_autofree gchar *layout_file = NULL;
+
+    layout_file = g_build_filename(pwd, PU_PACKAGE_LAYOUT_BASENAME, NULL);
+    if (!g_file_test(layout_file, G_FILE_TEST_IS_REGULAR)) {
+        g_set_error(error, PU_PACKAGE_ERROR, PU_PACKAGE_ERROR_MISSING_LAYOUT,
+                    "No layout file '%s' found", g_path_get_basename(layout_file));
+        return NULL;
+    }
+
+    return g_steal_pointer(&layout_file);
+}
+
+gboolean
+pu_package_create(gchar **files,
+                  const gchar *output,
+                  gboolean force_overwrite,
+                  GError **error)
+{
+    g_autofree gchar *cmd = NULL;
+    g_autofree gchar *input = NULL;
+    gboolean has_layout_yaml = FALSE;
+
+    g_return_val_if_fail(files != NULL, FALSE);
+    g_return_val_if_fail(g_strcmp0(output, "") > 0, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    /* Check if specified input files exist and search for required layout
+     * configuration file */
+    for (guint i = 0; i < g_strv_length(files); i++) {
+        g_autofree gchar *file = g_strdup(files[i]);
+
+        if (!g_file_test(file, G_FILE_TEST_EXISTS)) {
+            g_set_error(error, PU_PACKAGE_ERROR, PU_PACKAGE_ERROR_NOT_FOUND,
+                        "Input file '%s' does not exist", file);
+            return FALSE;
+        }
+
+        if (g_str_equal(file, "layout.yaml"))
+            has_layout_yaml = TRUE;
+    }
+
+    if (!has_layout_yaml) {
+        g_set_error(error, PU_PACKAGE_ERROR, PU_PACKAGE_ERROR_MISSING_LAYOUT,
+                    "Package input files do not contain a layout configuration "
+                    "named 'layout.yaml'");
+        return FALSE;
+    }
+
+    /* Check if specified output file exists and should be overwritten */
+    if (g_file_test(output, G_FILE_TEST_IS_REGULAR)) {
+        if (!force_overwrite) {
+            g_set_error(error, PU_PACKAGE_ERROR, PU_PACKAGE_ERROR_EXISTS,
+                        "Package '%s' already exists", output);
+            return FALSE;
+        }
+
+        g_remove(output);
+    }
+
+    input = g_strjoinv(" ", files);
+    cmd = g_strdup_printf("mksquashfs %s %s", input, output);
+
+    if (!pu_spawn_command_line_sync(cmd, error)) {
+        g_set_error(error, PU_PACKAGE_ERROR, PU_PACKAGE_ERROR_CREATION_FAILED,
+                    "Failed creating package '%s': ", output);
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+static gboolean
+print_dir_content(GFile *dir,
+                  gboolean recursive,
+                  gboolean print_size,
+                  GError **error)
+{
+    g_autoptr(GFileEnumerator) dir_enum = NULL;
+    g_autofree gchar *dir_path = NULL;
+    guint prefix_len = strlen(PU_PACKAGE_PREFIX) + 10; /* additional length of "-00000000/" */
+    guint64 child_size;
+    const gchar *file_attr = G_FILE_ATTRIBUTE_STANDARD_NAME ","
+                             G_FILE_ATTRIBUTE_STANDARD_SIZE;
+
+    dir_path = g_file_get_path(dir);
+    pu_str_pre_remove(dir_path, prefix_len);
+    if (strlen(dir_path))
+        g_print("%s/\n", dir_path);
+    dir_enum = g_file_enumerate_children(dir, file_attr, G_FILE_QUERY_INFO_NONE, NULL, error);
+    if (!dir_enum) {
+        g_set_error(error, PU_PACKAGE_ERROR, PU_PACKAGE_ERROR_ITER_FAILED,
+                    "Failed creating enumerator for '%s'",
+                    g_file_get_path(dir));
+        return FALSE;
+    }
+
+    while (TRUE) {
+        GFileInfo *child_info;
+        g_autofree gchar *child_path = NULL;
+
+        if (!g_file_enumerator_iterate(dir_enum, &child_info, NULL, NULL, error)) {
+            g_set_error(error, PU_PACKAGE_ERROR, PU_PACKAGE_ERROR_ITER_FAILED,
+                        "Failed iterating file enumerator for '%s'",
+                        g_file_get_path(dir));
+            return FALSE;
+        }
+
+        if (!child_info)
+            break;
+
+        child_path = g_build_filename(g_file_get_path(dir), g_file_info_get_name(child_info), NULL);
+        if (g_file_test(child_path, G_FILE_TEST_IS_DIR) && recursive) {
+            g_autoptr(GFile) subdir = g_file_new_for_path(child_path);
+
+            if (!print_dir_content(subdir, TRUE, print_size, error))
+                return FALSE;
+        } else {
+            pu_str_pre_remove(child_path, prefix_len);
+            g_print("%s", child_path);
+            if (print_size) {
+                child_size = g_file_info_get_size(child_info);
+                g_print(" (%s)", g_format_size(child_size));
+            }
+            g_print("\n");
+        }
+    }
+
+    return TRUE;
+}
+
+gboolean
+pu_package_list_contents(const gchar *package,
+                         gboolean print_size,
+                         GError **error)
+{
+    g_autofree gchar *dir_basename = NULL;
+    g_autofree gchar *mountpoint = NULL;
+    g_autofree gchar *layout_file = NULL;
+    g_autoptr(GFile) dir = NULL;
+
+    g_return_val_if_fail(g_strcmp0(package, "") > 0, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    if (!g_file_test(package, G_FILE_TEST_IS_REGULAR)) {
+        g_set_error(error, PU_PACKAGE_ERROR, PU_PACKAGE_ERROR_NOT_FOUND,
+                    "'%s' is not a regular file", package);
+        return FALSE;
+    }
+
+    if (!pu_package_mount(package, &mountpoint, &layout_file, error))
+        return FALSE;
+
+    dir = g_file_new_for_path(mountpoint);
+    if (!print_dir_content(dir, TRUE, print_size, error)) {
+        pu_umount(mountpoint, NULL);
+        return FALSE;
+    }
+
+    if (!pu_package_umount(mountpoint, error))
+        return FALSE;
+
+    return TRUE;
+}
+
+gboolean
+pu_package_mount(const gchar *package,
+                 gchar **mountpoint,
+                 gchar **layout_file,
+                 GError **error)
+{
+    g_return_val_if_fail(mountpoint != NULL && *mountpoint == NULL, FALSE);
+    g_return_val_if_fail(layout_file != NULL && *layout_file == NULL, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    if (!g_file_test(package, G_FILE_TEST_IS_REGULAR)) {
+        g_set_error(error, PU_PACKAGE_ERROR, PU_PACKAGE_ERROR_NOT_FOUND,
+                    "'%s' is not a regular file", package);
+        return FALSE;
+    }
+
+    *mountpoint = g_strdup_printf("%s-%08x", PU_PACKAGE_PREFIX, g_random_int());
+    if (!pu_create_mount_point(g_path_get_basename(*mountpoint), error))
+        return FALSE;
+
+    if (!pu_mount(package, *mountpoint, "squashfs", "loop,ro", error))
+        return FALSE;
+
+    *layout_file = pu_package_get_layout_file(*mountpoint, error);
+    if (*layout_file == NULL) {
+        g_prefix_error(error, "Invalid package: ");
+        pu_umount(*mountpoint, NULL);
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+gboolean
+pu_package_umount(const gchar *mountpoint,
+                  GError **error)
+{
+    g_return_val_if_fail(g_strcmp0(mountpoint, "") > 0, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    if (!pu_umount(mountpoint, error))
+        return FALSE;
+
+    if (g_rmdir(mountpoint) < 0) {
+        g_set_error(error, PU_PACKAGE_ERROR, PU_PACKAGE_ERROR_FAILED,
+                    "Failed cleaning up directory '%s'", mountpoint);
+        return FALSE;
+    }
+
+    return TRUE;
+}

--- a/src/pu-package.h
+++ b/src/pu-package.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2023 PHYTEC Messtechnik GmbH
+ */
+
+#ifndef PARTUP_PACKAGE_H
+#define PARTUP_PACKAGE_H
+
+#include <glib.h>
+#include "pu-mount.h"
+
+#define PU_PACKAGE_ERROR (pu_package_error_quark())
+
+GQuark pu_package_error_quark(void);
+
+typedef enum {
+    PU_PACKAGE_ERROR_CREATION_FAILED,
+    PU_PACKAGE_ERROR_EXISTS,
+    PU_PACKAGE_ERROR_ITER_FAILED,
+    PU_PACKAGE_ERROR_MISSING_LAYOUT,
+    PU_PACKAGE_ERROR_NOT_FOUND,
+    PU_PACKAGE_ERROR_FAILED
+} PuPackageError;
+
+#define PU_PACKAGE_BASENAME        "package"
+#define PU_PACKAGE_LAYOUT_BASENAME "layout.yaml"
+#define PU_PACKAGE_PREFIX          PU_MOUNT_PREFIX "/" PU_PACKAGE_BASENAME
+#define PU_PACKAGE_LAYOUT_FILE     PU_PACKAGE_PREFIX "/" PU_PACKAGE_LAYOUT_BASENAME
+
+gchar * pu_package_get_layout_file(const gchar *pwd,
+                                   GError **error);
+gboolean pu_package_create(gchar **files,
+                           const gchar *output,
+                           gboolean force_overwrite,
+                           GError **error);
+gboolean pu_package_list_contents(const gchar *package,
+                                  gboolean print_size,
+                                  GError **error);
+gboolean pu_package_mount(const gchar *package,
+                          gchar **mountpoint,
+                          gchar **layout_file,
+                          GError **error);
+gboolean pu_package_umount(const gchar *mountpoint,
+                           GError **error);
+
+#endif /* PARTUP_PACKAGE_H */

--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -428,3 +428,22 @@ pu_device_get_partition_path(const gchar *device,
         return NULL;
     }
 }
+
+gchar *
+pu_str_pre_remove(gchar *string,
+                  guint n)
+{
+    guchar *start;
+
+    g_return_val_if_fail(string != NULL, NULL);
+
+    if (n >= strlen(string))
+        n = strlen(string);
+
+    start = (guchar *) string;
+    start += n;
+
+    memmove(string, start, strlen((gchar *) start) + 1);
+
+    return string;
+}

--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -18,7 +18,7 @@
 
 #define UDEVADM_SETTLE_TIMEOUT 10
 
-static gboolean
+gboolean
 pu_spawn_command_line_sync(const gchar *command_line,
                            GError **error)
 {

--- a/src/pu-utils.h
+++ b/src/pu-utils.h
@@ -48,5 +48,7 @@ gchar * pu_path_from_uri(const gchar *uri,
 gchar * pu_device_get_partition_path(const gchar *device,
                                      guint index,
                                      GError **error);
+gchar * pu_str_pre_remove(gchar *string,
+                          guint n);
 
 #endif /* PARTUP_UTILS_H */

--- a/src/pu-utils.h
+++ b/src/pu-utils.h
@@ -9,6 +9,8 @@
 #include <glib.h>
 #include <parted/parted.h>
 
+gboolean pu_spawn_command_line_sync(const gchar *command_line,
+                                    GError **error);
 gboolean pu_file_copy(const gchar *src,
                       const gchar *dest,
                       GError **error);

--- a/tests/command.c
+++ b/tests/command.c
@@ -1,0 +1,215 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2023 PHYTEC Messtechnik GmbH
+ */
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+#include "pu-command.h"
+#include "pu-error.h"
+
+#define gen_argv(args) \
+    g_strsplit(g_strdup_printf("%s %s", g_get_prgname(), args), " ", -1)
+
+static gboolean
+cmd_empty(PuCommandContext *context,
+          GError **error)
+{
+    g_assert(context);
+    g_assert_no_error(*error);
+
+    return TRUE;
+}
+
+static gboolean
+cmd_basic_test(PuCommandContext *context,
+               GError **error)
+{
+    g_assert(context);
+    g_assert_no_error(*error);
+
+    g_assert_cmpstrv(NULL, pu_command_context_get_args(context)[0]);
+
+    return TRUE;
+}
+
+static void
+command_basic(void)
+{
+    g_autoptr(PuCommandContext) context = NULL;
+    g_autoptr(GError) error = NULL;
+
+    gchar **args = gen_argv("test");
+    PuCommandEntry entries[] =
+        { { "test", PU_COMMAND_ARG_NONE, cmd_basic_test,
+            "Test command description", NULL },
+          PU_COMMAND_ENTRY_NULL };
+
+    context = pu_command_context_new();
+    g_assert_nonnull(context);
+    pu_command_context_add_entries(context, entries, NULL);
+    pu_command_context_parse_strv(context, &args, &error);
+    g_assert_no_error(error);
+
+    g_assert(pu_command_context_invoke(context, &error));
+    g_assert_no_error(error);
+
+    g_strfreev(args);
+}
+
+static void
+command_help(void)
+{
+    g_autoptr(PuCommandContext) context = NULL;
+    g_autoptr(GError) error = NULL;
+    g_autofree gchar *str = NULL;
+
+    PuCommandEntry entries[] =
+        { { "foo", PU_COMMAND_ARG_NONE, cmd_empty,
+            "foo command description", NULL },
+          { "bar", PU_COMMAND_ARG_NONE, cmd_empty,
+            "bar command description", NULL },
+          PU_COMMAND_ENTRY_NULL };
+
+    context = pu_command_context_new();
+    g_assert_nonnull(context);
+    pu_command_context_add_entries(context, entries, NULL);
+
+    str = pu_command_context_get_help(context, NULL);
+    g_assert(strstr(str, "Commands") != NULL);
+    g_assert(strstr(str, entries[0].name) != NULL);
+    g_assert(strstr(str, entries[0].description) != NULL);
+    g_assert(strstr(str, entries[1].name) != NULL);
+    g_assert(strstr(str, entries[1].description) != NULL);
+
+    g_free(str);
+    str = pu_command_context_get_help(context, entries[0].name);
+    g_assert(strstr(str, entries[0].name) != NULL);
+    g_assert(strstr(str, "command description") != NULL);
+    g_assert(strstr(str, entries[0].description) != NULL);
+
+    g_free(str);
+    str = pu_command_context_get_help(context, entries[1].name);
+    g_assert(strstr(str, entries[1].name) != NULL);
+    g_assert(strstr(str, "command description") != NULL);
+    g_assert(strstr(str, entries[1].description) != NULL);
+}
+
+#define cmd_error_out() \
+{ \
+    g_set_error(error, PU_COMMAND_ERROR, PU_COMMAND_ERROR_FAILED, \
+                "Command '%s' failed", G_STRFUNC); \
+    return FALSE; \
+}
+
+static gboolean
+cmd_zero(PuCommandContext *context,
+         GError **error)
+{
+    g_return_val_if_fail(context != NULL, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    if (g_strv_length(pu_command_context_get_args(context)) != 0)
+        cmd_error_out();
+    if (pu_command_context_get_args(context)[0] != NULL)
+        cmd_error_out();
+
+    return TRUE;
+}
+
+static gboolean
+cmd_one(PuCommandContext *context,
+        GError **error)
+{
+    g_return_val_if_fail(context != NULL, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    if (g_strv_length(pu_command_context_get_args(context)) != 1)
+        cmd_error_out();
+    if (g_strcmp0(pu_command_context_get_args(context)[0], "") < 0)
+        cmd_error_out();
+    if (pu_command_context_get_args(context)[1] != NULL)
+        cmd_error_out();
+
+    return TRUE;
+}
+
+static gboolean
+cmd_two(PuCommandContext *context,
+        GError **error)
+{
+    g_return_val_if_fail(context != NULL, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    return TRUE;
+}
+
+static void
+command_arg(void)
+{
+    g_autoptr(PuCommandContext) context = NULL;
+    g_autoptr(GError) error = NULL;
+    gchar **args_zero = gen_argv("zero");
+    gchar **args_one = gen_argv("one first");
+    gchar **args_two = gen_argv("two first second");
+    gchar **args_zero_invalid = gen_argv("zero first_invalid second_invalid");
+    gchar **args_one_invalid = gen_argv("one first second_invalid");
+    gchar **args_two_invalid = gen_argv("two");
+
+    PuCommandEntry entries[] =
+        { { "zero", PU_COMMAND_ARG_NONE, cmd_zero,
+            "command with zero arguments", NULL },
+          { "one", PU_COMMAND_ARG_FILENAME, cmd_one,
+            "command with one argument", NULL },
+          { "two", PU_COMMAND_ARG_FILENAME_ARRAY, cmd_two,
+            "command with two or more arguments", NULL },
+          PU_COMMAND_ENTRY_NULL };
+
+    context = pu_command_context_new();
+    g_assert_nonnull(context);
+    pu_command_context_add_entries(context, entries, NULL);
+
+    pu_command_context_parse_strv(context, &args_zero, &error);
+    g_assert_no_error(error);
+    g_assert(pu_command_context_invoke(context, &error));
+    g_assert_no_error(error);
+
+    pu_command_context_parse_strv(context, &args_one, &error);
+    g_assert_no_error(error);
+    g_assert(pu_command_context_invoke(context, &error));
+    g_assert_no_error(error);
+
+    pu_command_context_parse_strv(context, &args_two, &error);
+    g_assert_no_error(error);
+    g_assert(pu_command_context_invoke(context, &error));
+    g_assert_no_error(error);
+
+    g_assert_false(pu_command_context_parse_strv(context, &args_zero_invalid, &error));
+    g_assert_error(error, PU_COMMAND_ERROR, PU_COMMAND_ERROR_BAD_VALUE);
+    g_clear_error(&error);
+
+    g_assert_false(pu_command_context_parse_strv(context, &args_one_invalid, &error));
+    g_assert_error(error, PU_COMMAND_ERROR, PU_COMMAND_ERROR_BAD_VALUE);
+    g_clear_error(&error);
+
+    g_assert_false(pu_command_context_parse_strv(context, &args_two_invalid, &error));
+    g_assert_error(error, PU_COMMAND_ERROR, PU_COMMAND_ERROR_BAD_VALUE);
+}
+
+int
+main(int argc,
+     char *argv[])
+{
+    g_test_init(&argc, &argv, NULL);
+
+#ifdef PARTUP_TEST_SRCDIR
+    g_chdir(PARTUP_TEST_SRCDIR);
+#endif
+
+    g_test_add_func("/command/basic", command_basic);
+    g_test_add_func("/command/help", command_help);
+    g_test_add_func("/command/arg", command_arg);
+
+    return g_test_run();
+}

--- a/tests/helper.h
+++ b/tests/helper.h
@@ -7,6 +7,7 @@
 #define PARTUP_TEST_HELPER_H
 
 #include <glib.h>
+#include <gio/gio.h>
 
 typedef struct {
     GError *error;
@@ -21,6 +22,13 @@ typedef struct {
     gchar *loop_dev;
 } EmptyDeviceFixture;
 
+typedef struct {
+    gchar **input_files;
+    gchar *path_tmp;
+    gchar *path_test;
+    GError *error;
+} PackageFilesFixture;
+
 GFile * create_tmp_file(const gchar *filename,
                         const gchar *pwd,
                         gsize size,
@@ -33,5 +41,9 @@ void empty_device_set_up(EmptyDeviceFixture *fixture,
                          G_GNUC_UNUSED gconstpointer user_data);
 void empty_device_tear_down(EmptyDeviceFixture *fixture,
                             G_GNUC_UNUSED gconstpointer user_data);
+void package_files_setup(PackageFilesFixture *fixture,
+                         gconstpointer user_data);
+void package_files_teardown(PackageFilesFixture *fixture,
+                            gconstpointer user_data);
 
 #endif /* PARTUP_TEST_HELPER_H */

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3,10 +3,12 @@ tests = [
   'command',
   'config',
   'emmc',
+  'package',
   'utils'
 ]
 
 tests_root = [
+  'package-root',
   'utils-root'
 ]
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,5 +1,6 @@
 tests = [
   'checksum',
+  'command',
   'config',
   'emmc',
   'utils'

--- a/tests/package-root.c
+++ b/tests/package-root.c
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2023 PHYTEC Messtechnik GmbH
+ */
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+#include "pu-package.h"
+#include "helper.h"
+
+#define PACKAGE_FILENAME "package.partup"
+
+static void
+package_list_contents(PackageFilesFixture *fixture,
+                      G_GNUC_UNUSED gconstpointer user_data)
+{
+    g_autoptr(GFile) package_file = NULL;
+
+    g_chdir(fixture->path_tmp);
+
+    g_assert(pu_package_create(fixture->input_files, PACKAGE_FILENAME, FALSE, &fixture->error));
+    g_assert_no_error(fixture->error);
+
+    g_assert(pu_package_list_contents(PACKAGE_FILENAME, TRUE, &fixture->error));
+    g_assert_no_error(fixture->error);
+
+    package_file = g_file_new_build_filename(fixture->path_tmp, PACKAGE_FILENAME, NULL);
+    g_assert_true(g_file_delete(package_file, NULL, &fixture->error));
+    g_assert_no_error(fixture->error);
+
+    g_chdir(fixture->path_test);
+}
+
+static void
+package_mount(PackageFilesFixture *fixture,
+              G_GNUC_UNUSED gconstpointer user_data)
+{
+    g_autoptr(GFile) package_file = NULL;
+    g_autofree gchar *mountpoint = NULL;
+    g_autofree gchar *config_path = NULL;
+
+    g_chdir(fixture->path_tmp);
+
+    g_assert(pu_package_create(fixture->input_files, PACKAGE_FILENAME, FALSE, &fixture->error));
+    g_assert_no_error(fixture->error);
+
+    g_assert(pu_package_mount(PACKAGE_FILENAME, &mountpoint, &config_path, &fixture->error));
+    g_assert(g_file_test(mountpoint, G_FILE_TEST_IS_DIR));
+    g_assert(g_file_test(config_path, G_FILE_TEST_IS_REGULAR));
+
+    for (guint i = 0; i < g_strv_length(fixture->input_files); i++)
+        g_assert(g_file_test(fixture->input_files[i], G_FILE_TEST_IS_REGULAR));
+
+    g_assert(pu_package_umount(mountpoint, &fixture->error));
+    g_assert_no_error(fixture->error);
+
+    package_file = g_file_new_build_filename(fixture->path_tmp, PACKAGE_FILENAME, NULL);
+    g_assert_true(g_file_delete(package_file, NULL, &fixture->error));
+    g_assert_no_error(fixture->error);
+
+    g_chdir(fixture->path_test);
+}
+
+int
+main(int argc,
+     char *argv[])
+{
+    /* Skip tests when not run as root */
+    if (getuid() != 0)
+        return 77;
+
+    g_test_init(&argc, &argv, NULL);
+
+#ifdef PARTUP_TEST_SRCDIR
+    g_chdir(PARTUP_TEST_SRCDIR);
+#endif
+
+    g_test_add("/package/list-contents", PackageFilesFixture, NULL,
+               package_files_setup, package_list_contents, package_files_teardown);
+    g_test_add("/package/mount", PackageFilesFixture, NULL,
+               package_files_setup, package_mount, package_files_teardown);
+
+    return g_test_run();
+}

--- a/tests/package.c
+++ b/tests/package.c
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2023 PHYTEC Messtechnik GmbH
+ */
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+#include "pu-package.h"
+#include "helper.h"
+
+#define PACKAGE_FILENAME "package.partup"
+
+static void
+package_create(PackageFilesFixture *fixture,
+               G_GNUC_UNUSED gconstpointer user_data)
+{
+    g_autoptr(GFile) package_file = NULL;
+    g_assert(g_chdir(fixture->path_tmp) == 0);
+
+    g_assert_true(pu_package_create(fixture->input_files, PACKAGE_FILENAME, FALSE, &fixture->error));
+    g_assert_no_error(fixture->error);
+
+    package_file = g_file_new_build_filename(fixture->path_tmp, PACKAGE_FILENAME, NULL);
+    g_assert_true(g_file_delete(package_file, NULL, &fixture->error));
+    g_assert_no_error(fixture->error);
+
+    g_assert(g_chdir(fixture->path_test) == 0);
+}
+
+int
+main(int argc,
+     char *argv[])
+{
+    g_test_init(&argc, &argv, NULL);
+
+#ifdef PARTUP_TEST_SRCDIR
+    g_chdir(PARTUP_TEST_SRCDIR);
+#endif
+
+    g_test_add("/package/create", PackageFilesFixture, NULL,
+               package_files_setup, package_create, package_files_teardown);
+
+    return g_test_run();
+}


### PR DESCRIPTION
This introduces "commands" for partup, mainly to add support for its new "package" format `.partup`. Currently working commands allow for creating packages, showing their content and installing them to a device. A package includes both the layout configuration file and all needed input files.

This is **work in progress**, so there is still a lot of cleanup and some missing work to do. Some tasks include:

- [x] Squash commits and add proper commit messages
- [x] Add support for appending command specific options, like `partup package -f mypackage.partup file1 file2 file3`
- [x] Add checks during packaging for correct layout file placement
- [x] Add command documentation (which commands exist, how to use them)
- [x] Add package documentation (how they internally work, what their requirements are, how to create them)
- [x] Automatic generation of command help text
- [x] Remove any debug junk
- [x] Create unit test for command module
- [x] Create unit test for package module
- [x] Remove temporary directory `/run/partup/package-XXXXXXXX` after showing package contents
- [ ] Find a way to dynamically adjust the parameter string of the `GOptionContext` to show the correct usage depending on the currently used command (WONTFIX in this PR)