### PR TITLE
meson.build: Add option to link GLib and GIO statically

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,7 +24,7 @@ configure_file(
 
 deps = [
   dependency('glib-2.0', static : get_option('static-glib'), version : '>=2.66.0'),
-  dependency('gio-2.0', static : get_option('static-glib')),
+  dependency('gio-2.0', static : get_option('static-glib'), version : '>=2.66.0'),
   dependency('yaml-0.1'),
   dependency('libparted'),
   dependency('mount'),

--- a/meson.build
+++ b/meson.build
@@ -23,8 +23,8 @@ configure_file(
 )
 
 deps = [
-  dependency('glib-2.0', version : '>=2.66.0'),
-  dependency('gio-2.0'),
+  dependency('glib-2.0', static : get_option('static-glib'), version : '>=2.66.0'),
+  dependency('gio-2.0', static : get_option('static-glib')),
   dependency('yaml-0.1'),
   dependency('libparted'),
   dependency('mount'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,6 +2,10 @@ option('doc',
        type: 'boolean',
        value: false,
        description: 'Build the documentation')
+option('static-glib',
+       type: 'boolean',
+       value: false,
+       description: 'Statically link GLib and GIO to partup')
 option('tests',
        type: 'boolean',
        value: true,


### PR DESCRIPTION
Add a build option enabling to statically link GLib and GIO to partup. This is useful to support older systems, where the version of GLib may be too old and does not contain required functions.

While at it, require the same minimum version for GIO as for GLib. These two usually have the same version anyway.