### PR TITLE
Improve debug and message output with color and more structure

### DIFF
--- a/src/pu-log.c
+++ b/src/pu-log.c
@@ -6,7 +6,7 @@
 #include <glib.h>
 #include "pu-log.h"
 
-#define PU_LOG_DOMAINS "partup partup-config partup-emmc partup-mount partup-utils"
+#define PU_LOG_DOMAINS "partup partup-config partup-emmc partup-mount partup-package partup-utils"
 
 GLogLevelFlags log_output_level;
 

--- a/src/pu-log.c
+++ b/src/pu-log.c
@@ -9,7 +9,7 @@
 
 #define PU_LOG_DOMAINS "partup partup-config partup-emmc partup-mount partup-package partup-utils"
 
-GLogLevelFlags log_output_level;
+GLogLevelFlags log_output_level = G_LOG_LEVEL_INFO;
 
 static void
 append_log_time(GString *log_str)

--- a/src/pu-log.c
+++ b/src/pu-log.c
@@ -182,8 +182,7 @@ pu_log_set_debug_domains(gboolean quiet,
         new_domains = g_string_new(g_getenv("G_MESSAGES_DEBUG"));
         debug_arr = g_strsplit(debug_domains, ",", 0);
         for (int i = 0; debug_arr[i] != NULL; i++) {
-            g_string_append(new_domains,
-                            g_strdup_printf("partup-%s", debug_arr[i]));
+            g_string_append(new_domains, g_strdup(debug_arr[i]));
         }
         g_strfreev(debug_arr);
         g_setenv("G_MESSAGES_DEBUG", new_domains->str, TRUE);

--- a/src/pu-log.c
+++ b/src/pu-log.c
@@ -152,9 +152,15 @@ pu_log_writer(GLogLevelFlags log_level,
 }
 
 void
-pu_log_setup(gboolean quiet,
-             gboolean debug,
-             const gchar *debug_domains)
+pu_log_init(void)
+{
+    g_log_set_writer_func(pu_log_writer, NULL, NULL);
+}
+
+void
+pu_log_set_debug_domains(gboolean quiet,
+                         gboolean debug,
+                         const gchar *debug_domains)
 {
     g_autoptr(GString) new_domains = NULL;
     const gchar *domains;
@@ -185,6 +191,4 @@ pu_log_setup(gboolean quiet,
     } else {
         log_output_level = G_LOG_LEVEL_MESSAGE;
     }
-
-    g_log_set_writer_func(pu_log_writer, NULL, NULL);
 }

--- a/src/pu-log.c
+++ b/src/pu-log.c
@@ -183,7 +183,7 @@ pu_log_setup(gboolean quiet,
         g_setenv("G_MESSAGES_DEBUG", new_domains->str, TRUE);
         log_output_level = G_LOG_LEVEL_DEBUG;
     } else {
-        log_output_level = G_LOG_LEVEL_INFO;
+        log_output_level = G_LOG_LEVEL_MESSAGE;
     }
 
     g_log_set_writer_func(pu_log_writer, NULL, NULL);

--- a/src/pu-log.c
+++ b/src/pu-log.c
@@ -4,31 +4,151 @@
  */
 
 #include <glib.h>
+#include <stdio.h>
 #include "pu-log.h"
 
 #define PU_LOG_DOMAINS "partup partup-config partup-emmc partup-mount partup-package partup-utils"
 
 GLogLevelFlags log_output_level;
 
+static void
+append_log_time(GString *log_str)
+{
+    g_autoptr(GDateTime) datetime = NULL;
+
+    datetime = g_date_time_new_now_local();
+    g_string_append_printf(log_str, "%s", g_date_time_format(datetime, "%H:%M:%S.%f"));
+}
+
+static void
+append_log_level(GString *log_str,
+                 GLogLevelFlags log_level,
+                 gboolean color)
+{
+    if (color) {
+        switch (log_level) {
+        case G_LOG_LEVEL_ERROR:
+            g_string_append(log_str, "\033[1;35mERROR\033[0m");
+            break;
+        case G_LOG_LEVEL_CRITICAL:
+            g_string_append(log_str, "\033[1;31mCRITICAL\033[0m");
+            break;
+        case G_LOG_LEVEL_WARNING:
+            g_string_append(log_str, "\033[1;33mWARNING\033[0m");
+            break;
+        case G_LOG_LEVEL_MESSAGE:
+            g_string_append(log_str, "\033[1;34mMESSAGE\033[0m");
+            break;
+        case G_LOG_LEVEL_INFO:
+            g_string_append(log_str, "\033[1;36mINFO\033[0m");
+            break;
+        case G_LOG_LEVEL_DEBUG:
+            g_string_append(log_str, "\033[1;32mDEBUG\033[0m");
+            break;
+        default:
+            g_string_append(log_str, "\033[1;37mUNKNOWN\033[0m");
+        }
+    } else {
+        switch (log_level) {
+        case G_LOG_LEVEL_ERROR:
+            g_string_append(log_str, "ERROR");
+            break;
+        case G_LOG_LEVEL_CRITICAL:
+            g_string_append(log_str, "CRITICAL");
+            break;
+        case G_LOG_LEVEL_WARNING:
+            g_string_append(log_str, "WARNING");
+            break;
+        case G_LOG_LEVEL_MESSAGE:
+            g_string_append(log_str, "MESSAGE");
+            break;
+        case G_LOG_LEVEL_INFO:
+            g_string_append(log_str, "INFO");
+            break;
+        case G_LOG_LEVEL_DEBUG:
+            g_string_append(log_str, "DEBUG");
+            break;
+        default:
+            g_string_append(log_str, "UNKNOWN");
+        }
+    }
+}
+
+static void
+append_log_domain(GString *log_str,
+                  const gchar *log_domain,
+                  gboolean color)
+{
+    g_return_if_fail(log_domain && *log_domain);
+
+    if (color)
+        g_string_append(log_str, "\033[0;37m");
+
+    g_string_append_printf(log_str, "%s", log_domain);
+
+    if (color)
+        g_string_append(log_str, "\033[0m");
+}
+
+static GLogWriterOutput
+pu_log_writer_formatted(GLogLevelFlags log_level,
+                        const gchar *log_domain,
+                        const gchar *log_message,
+                        G_GNUC_UNUSED const GLogField *fields,
+                        G_GNUC_UNUSED gsize n_fields)
+{
+    g_autoptr(GString) log_str = NULL;
+    gboolean use_color;
+    FILE *stream = stdout;
+
+    log_str = g_string_new(NULL);
+    use_color = g_log_writer_supports_color(fileno(stream));
+
+    if (log_output_level > G_LOG_LEVEL_MESSAGE || log_level < G_LOG_LEVEL_MESSAGE) {
+        append_log_time(log_str);
+        g_string_append_c(log_str, ' ');
+        append_log_level(log_str, log_level, use_color);
+        g_string_append_c(log_str, ' ');
+        append_log_domain(log_str, log_domain, use_color);
+        g_string_append(log_str, ": ");
+    }
+
+    g_string_append_printf(log_str, "%s", log_message);
+
+    fprintf(stream, "%s\n", log_str->str);
+    fflush(stream);
+
+    if (log_level & G_LOG_FLAG_FATAL)
+        g_abort();
+
+    return G_LOG_WRITER_HANDLED;
+}
+
 static GLogWriterOutput
 pu_log_writer(GLogLevelFlags log_level,
               const GLogField *fields,
               gsize n_fields,
-              gpointer user_data)
+              G_GNUC_UNUSED gpointer user_data)
 {
     const gchar *log_domain = NULL;
+    const gchar *log_message = NULL;
 
-    for (gsize i = 0; i < n_fields; i++) {
-        if (g_strcmp0(fields[i].key, "GLIB_DOMAIN") == 0) {
+    for (gsize i = 0; (!log_domain || !log_message) && i < n_fields; i++) {
+        if (g_strcmp0(fields[i].key, "GLIB_DOMAIN") == 0)
             log_domain = fields[i].value;
-            break;
-        }
+        else if (g_strcmp0(fields[i].key, "MESSAGE") == 0)
+            log_message = fields[i].value;
     }
+
+    if (!log_domain)
+        log_domain = "(NULL domain)";
+    if (!log_message)
+        log_message = "(NULL message)";
 
     if (log_level > log_output_level || g_log_writer_default_would_drop(log_level, log_domain))
         return G_LOG_WRITER_HANDLED;
 
-    return g_log_writer_standard_streams(log_level, fields, n_fields, user_data);
+    return pu_log_writer_formatted(log_level, log_domain, log_message, fields, n_fields);
 }
 
 void

--- a/src/pu-log.h
+++ b/src/pu-log.h
@@ -8,8 +8,9 @@
 
 #include <glib.h>
 
-void pu_log_setup(gboolean quiet,
-                  gboolean debug,
-                  const gchar *debug_domains);
+void pu_log_init(void);
+void pu_log_set_debug_domains(gboolean quiet,
+                              gboolean debug,
+                              const gchar *debug_domains);
 
 #endif /* PARTUP_LOG_H */

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -171,7 +171,7 @@ static gboolean
 cmd_version(G_GNUC_UNUSED PuCommandContext *context,
             G_GNUC_UNUSED GError **error)
 {
-    g_print("%s %s\n", g_get_prgname(), PARTUP_VERSION_STRING);
+    g_message("%s %s", g_get_prgname(), PARTUP_VERSION_STRING);
 
     return TRUE;
 }
@@ -239,14 +239,14 @@ main(G_GNUC_UNUSED int argc,
     context_cmd = pu_command_context_new();
     pu_command_context_add_entries(context_cmd, command_entries, option_entries_main);
     if (!pu_command_context_parse_strv(context_cmd, &args, &error)) {
-        g_printerr("ERROR: %s\n", error->message);
+        g_critical("%s", error->message);
         return 1;
     }
 
     pu_log_set_debug_domains(arg_quiet, arg_debug, arg_debug_domains);
 
     if (!pu_command_context_invoke(context_cmd, &error)) {
-        g_printerr("ERROR: %s\n", error->message);
+        g_critical("%s", error->message);
         return 1;
     }
 

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -234,6 +234,8 @@ main(G_GNUC_UNUSED int argc,
     setlocale(LC_ALL, "");
     args = g_strdupv(argv);
 
+    pu_log_init();
+
     context_cmd = pu_command_context_new();
     pu_command_context_add_entries(context_cmd, command_entries, option_entries_main);
     if (!pu_command_context_parse_strv(context_cmd, &args, &error)) {
@@ -241,7 +243,7 @@ main(G_GNUC_UNUSED int argc,
         return 1;
     }
 
-    pu_log_setup(arg_quiet, arg_debug, arg_debug_domains);
+    pu_log_set_debug_domains(arg_quiet, arg_debug, arg_debug_domains);
 
     if (!pu_command_context_invoke(context_cmd, &error)) {
         g_printerr("ERROR: %s\n", error->message);


### PR DESCRIPTION
* Improve the regular messages and debug output being printed in the `PuEmmc` module.
* Use `g_message()` logging for printing package output. This allows for showing more detailed output when enabling debug options.
* Add a custom logging writer that can format output messages with color, if supported. The output format is slightly tuned from the default coming from GLib, to be shorter and easier to read.
* Set the default logging level to display regular "messages", instead of the slightly higher level "info". This allows printing regular output with `g_message()` without enabling debug output.
* Split the logging setup function into initializing the writer function and setting the current debug level.
* Allow passing the full debug domain, instead of always prefixing it with "partup-". This also allows passing foreign debug domains not specified in partup, e.g. those coming from GLib.
* Use the logging functions in main instead of plain printing for outputting error messages. This has the advantage of nicely formatted error messages.