### PR TITLE
src: pu-mount: Fix mount detection on devices without partitions

### DIFF
--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -461,6 +461,24 @@ pu_device_get_partition_path(const gchar *device,
 }
 
 gchar *
+pu_device_get_partition_pattern(const gchar *device,
+                                GError **error)
+{
+    g_return_val_if_fail(g_strcmp0(device, "") > 0, NULL);
+    g_return_val_if_fail(error == NULL || *error == NULL, NULL);
+
+    if (g_regex_match_simple("(mmcblk|loop)[0-9]+", device, 0, 0)) {
+        return g_strdup_printf("^%s($|p[0-9]+)", device);
+    } else if (g_regex_match_simple("sd[a-z]+", device, 0, 0)) {
+        return g_strdup_printf("^%s($|[0-9]+)", device);
+    } else {
+        g_set_error(error, PU_ERROR, PU_ERROR_FAILED,
+                    "Invalid device name '%s'", device);
+        return NULL;
+    }
+}
+
+gchar *
 pu_str_pre_remove(gchar *string,
                   guint n)
 {

--- a/src/pu-utils.h
+++ b/src/pu-utils.h
@@ -52,6 +52,8 @@ gchar * pu_path_from_uri(const gchar *uri,
 gchar * pu_device_get_partition_path(const gchar *device,
                                      guint index,
                                      GError **error);
+gchar * pu_device_get_partition_pattern(const gchar *device,
+                                        GError **error);
 gchar * pu_str_pre_remove(gchar *string,
                           guint n);
 

--- a/tests/mount-root.c
+++ b/tests/mount-root.c
@@ -80,19 +80,19 @@ test_device_mounted_false(EmptyDeviceFixture *fixture,
                           G_GNUC_UNUSED gconstpointer user_data)
 {
     gboolean is_mounted;
-    g_autofree gchar *mount_point = NULL;
 
-    mount_point = g_dir_make_tmp("partup-XXXXXX", &fixture->error);
-    g_assert_no_error(fixture->error);
-
-    create_partition(fixture->loop_dev, &fixture->error);
-    g_assert_no_error(fixture->error);
-
+    /* Test unpartitioned device */
     g_assert_true(pu_device_mounted(fixture->loop_dev, &is_mounted, &fixture->error));
     g_assert_no_error(fixture->error);
     g_assert_false(is_mounted);
 
-    g_assert_cmpint(g_rmdir(mount_point), ==, 0);
+    create_partition(fixture->loop_dev, &fixture->error);
+    g_assert_no_error(fixture->error);
+
+    /* Test partitioned device */
+    g_assert_true(pu_device_mounted(fixture->loop_dev, &is_mounted, &fixture->error));
+    g_assert_no_error(fixture->error);
+    g_assert_false(is_mounted);
 }
 
 static void

--- a/tests/utils.c
+++ b/tests/utils.c
@@ -197,6 +197,30 @@ test_str_pre_remove(void)
     g_assert_cmpstr(in, ==, "up");
 }
 
+static void
+test_device_get_partition_pattern(void)
+{
+    g_autoptr(GError) error = NULL;
+    g_autofree gchar *pattern;
+
+    pattern = pu_device_get_partition_pattern("/dev/mmcblk0", &error);
+    g_assert_no_error(error);
+    g_assert_true(g_regex_match_simple(pattern, "/dev/mmcblk0", 0, 0));
+    g_assert_true(g_regex_match_simple(pattern, "/dev/mmcblk0p1", 0, 0));
+    g_free(pattern);
+
+    pattern = pu_device_get_partition_pattern("/dev/loop1", &error);
+    g_assert_no_error(error);
+    g_assert_true(g_regex_match_simple(pattern, "/dev/loop1p1", 0, 0));
+    g_assert_false(g_regex_match_simple(pattern, "/dev/loop10", 0, 0));
+    g_free(pattern);
+
+    pattern = pu_device_get_partition_pattern("/dev/sda", &error);
+    g_assert_no_error(error);
+    g_assert_true(g_regex_match_simple(pattern, "/dev/sda1", 0, 0));
+    g_assert_false(g_regex_match_simple(pattern, "/dev/sdb1", 0, 0));
+}
+
 int
 main(int argc,
      char *argv[])
@@ -228,6 +252,7 @@ main(int argc,
     g_test_add_func("/utils/get_file_size",
                     test_get_file_size);
     g_test_add_func("/utils/str_pre_remove", test_str_pre_remove);
+    g_test_add_func("/utils/device_get_partition_pattern", test_device_get_partition_pattern);
 
     return g_test_run();
 }


### PR DESCRIPTION
Use libmount instead of libblkid to detect mounted partitions. This fixes a bug introduced in
dab8dae32ade (src: mount: Use libmount in pu_device_mounted) which prevented the use of partup with devices without a partition table.