### PR TITLE
remove file:// scheme from relative paths

### DIFF
--- a/doc/data/layout-ab-emmc.yaml
+++ b/doc/data/layout-ab-emmc.yaml
@@ -6,7 +6,7 @@ emmc-boot-partitions:
   input-offset: 0
   output-offset: 0
   input:
-    uri: file://barebox.bin
+    filename: barebox.bin
     md5sum: 46b1db79bc81e7af11b29436fb7a2515
     sha256sum: a4d0b0802fc30fbdc987def1975f665190aa35af64fcd9dae26fc1b121c71966
 
@@ -20,7 +20,7 @@ raw:
   - input-offset: 1kiB
     output-offset: 1kiB
     input:
-      uri: file://barebox.bin
+      filename: barebox.bin
       md5sum: 46b1db79bc81e7af11b29436fb7a2515
       sha256sum: a4d0b0802fc30fbdc987def1975f665190aa35af64fcd9dae26fc1b121c71966
 
@@ -31,10 +31,10 @@ partitions:
     size: 64MiB
     offset: 4MiB
     input:
-      - uri: file://zImage
+      - filename: zImage
         md5sum: 03d010a6850653344b7120da813ef282
         sha256sum: 545420a94b3e7d92e61d87523fc263f5abe7820b144e5e444f59f345adb87762
-      - uri: file://oftree
+      - filename: oftree
         md5sum: a48a06a5c3fbbfb89f0591710ca120c0
         sha256sum: c40b7c2f6e669aea45385eaec60a0af4a7f7a328c0bef6ab2a173bf6143da61e
 
@@ -43,10 +43,10 @@ partitions:
     filesystem: fat32
     size: 64MiB
     input:
-      - uri: file://zImage
+      - filename: zImage
         md5sum: 03d010a6850653344b7120da813ef282
         sha256sum: 545420a94b3e7d92e61d87523fc263f5abe7820b144e5e444f59f345adb87762
-      - uri: file://oftree
+      - filename: oftree
         md5sum: a48a06a5c3fbbfb89f0591710ca120c0
         sha256sum: c40b7c2f6e669aea45385eaec60a0af4a7f7a328c0bef6ab2a173bf6143da61e
 
@@ -55,7 +55,7 @@ partitions:
     filesystem: ext4
     size: 192MiB
     input:
-      - uri: file://config-partition.tar.gz
+      - filename: config-partition.tar.gz
 
   - label: ROOT0
     type: logical
@@ -63,7 +63,7 @@ partitions:
     expand: true
     block-size: 4kiB
     input:
-      - uri: file://rootfs.ext4
+      - filename: rootfs.ext4
 
   - label: ROOT1
     type: logical
@@ -71,4 +71,4 @@ partitions:
     expand: true
     block-size: 4kiB
     input:
-      - uri: file://rootfs.ext4
+      - filename: rootfs.ext4

--- a/doc/data/layout-simple.yaml
+++ b/doc/data/layout-simple.yaml
@@ -5,7 +5,7 @@ raw:
   - input-offset: 0
     output-offset: 33kiB
     input:
-      uri: file://u-boot.bin
+      filename: u-boot.bin
 
 partitions:
   - type: primary
@@ -13,12 +13,12 @@ partitions:
     size: 128MiB
     offset: 4MiB
     input:
-      - uri: file://Image
-      - uri: file://oftree
-      - uri: file://bootenv.txt
+      - filename: Image
+      - filename: oftree
+      - filename: bootenv.txt
 
   - type: primary
     filesystem: ext4
     expand: true
     input:
-      - uri: file://rootfs.tar.gz
+      - filename: rootfs.tar.gz

--- a/doc/layout-config-reference.rst
+++ b/doc/layout-config-reference.rst
@@ -120,22 +120,22 @@ Input Files
 -----------
 
 Input files are specified by a scalar named ``input`` containing a mapping with
-at least a ``uri``. For verifying the checksum of the given file by ``uri``, an
-optional checksum can be provided with ``md5sum`` and/or ``sha256sum``.
+at least a ``filename``. For verifying the checksum of the given file by
+``filename``, an optional checksum can be provided with ``md5sum`` and/or
+``sha256sum``.
 
-``uri`` (string)
-   A valid URI pointing to a file that should be written to the parent partition
-   or volume. Currently supported URI schemes are:
-
-   * ``file://`` with an absolute or relative path to a local file.
+``filename`` (string)
+   A valid relativ path pointing to a file that should be written to the parent
+   partition or volume.
 
 ``md5sum`` (string)
-   The MD5 sum of the given file specified by ``uri``. This sum is checked
+   The MD5 sum of the given file specified by ``filename``. This sum is checked
    against the provided file before writing to the target partition or volume.
 
 ``sha256sum`` (string)
-   The SHA256 sum of the given file specified by ``uri``. This sum is checked
-   against the provided file before writing to the target partition or volume.
+   The SHA256 sum of the given file specified by ``filename``. This sum is
+   checked against the provided file before writing to the target partition or
+   volume.
 
 Supported File Types
 ....................

--- a/src/pu-flash.c
+++ b/src/pu-flash.c
@@ -140,8 +140,8 @@ pu_flash_class_init(PuFlashClass *class)
                              G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
     props[PROP_PREFIX] =
         g_param_spec_string("prefix",
-                            "URI prefix path",
-                            "Path to prefix all file URIs with in the layout configuration",
+                            "Filename prefix path",
+                            "Path to prefix all input filenames with in the layout configuration",
                             NULL,
                             G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
     props[PROP_SKIP_CHECKSUMS] =

--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -402,42 +402,28 @@ pu_get_file_size(const gchar *path,
 }
 
 gchar *
-pu_path_from_uri(const gchar *uri,
-                 const gchar *prefix,
-                 GError **error)
+pu_path_from_filename(const gchar *filename,
+                      const gchar *prefix,
+                      GError **error)
 {
-    g_autofree gchar *path = NULL;
-    g_autofree gchar *scheme = NULL;
-    g_autofree gchar *host = NULL;
-
     g_return_val_if_fail(error == NULL || *error == NULL, NULL);
 
-    if (g_strcmp0(uri, "") <= 0) {
+    if (g_strcmp0(filename, "") <= 0) {
         g_set_error(error, PU_ERROR, PU_ERROR_FAILED,
-                    "URI is empty");
+                    "filename is empty");
         return NULL;
     }
 
-    if (!g_uri_split(uri, G_URI_FLAGS_NONE, &scheme, NULL, &host, NULL, &path,
-                     NULL, NULL, error))
-        return NULL;
-
-    if (g_strcmp0(scheme, "file") != 0 && g_strcmp0(scheme, "") > 0) {
+    if (g_path_is_absolute(filename)) {
         g_set_error(error, PU_ERROR, PU_ERROR_FAILED,
-                    "Invalid scheme '%s' for file path", scheme);
+                    "Filename '%s' must be relative", filename);
         return NULL;
     }
 
-    if (g_strcmp0(path, "") <= 0)
-        path = g_strdup(host);
-
-    if (!g_path_is_absolute(path) && g_strcmp0(prefix, "") > 0) {
-        g_autofree gchar *tmp_path = g_strdup(path);
-        g_free(path);
-        path = g_build_filename(prefix, tmp_path, NULL);
-    }
-
-    return g_strdup(path);
+    if (g_strcmp0(prefix, "") > 0)
+        return g_build_filename(prefix, filename, NULL);
+    else
+        return g_strdup(filename);
 }
 
 gchar *

--- a/src/pu-utils.h
+++ b/src/pu-utils.h
@@ -46,9 +46,9 @@ gboolean pu_is_drive(const gchar *device);
 gboolean pu_wait_for_partitions(GError **error);
 goffset pu_get_file_size(const gchar *path,
                          GError **error);
-gchar * pu_path_from_uri(const gchar *uri,
-                         const gchar *prefix,
-                         GError **error);
+gchar * pu_path_from_filename(const gchar *filename,
+                              const gchar *prefix,
+                              GError **error);
 gchar * pu_device_get_partition_path(const gchar *device,
                                      guint index,
                                      GError **error);

--- a/tests/config/raw-non-overlap.yaml
+++ b/tests/config/raw-non-overlap.yaml
@@ -5,11 +5,11 @@ raw:
   - input-offset: 0
     output-offset: 33KiB
     input:
-      uri: random.bin
+      filename: random.bin
   - input-offset: 0
     output-offset: 1MiB
     input:
-      uri: random.bin
+      filename: random.bin
 
 partitions:
   - type: primary

--- a/tests/config/raw-overlap-partition-table.yaml
+++ b/tests/config/raw-overlap-partition-table.yaml
@@ -5,11 +5,11 @@ raw:
   - input-offset: 0
     output-offset: 0
     input:
-      uri: random.bin
+      filename: random.bin
   - input-offset: 0
     output-offset: 1MiB
     input:
-      uri: random.bin
+      filename: random.bin
 
 partitions:
   - type: primary

--- a/tests/config/raw-overlap-partition.yaml
+++ b/tests/config/raw-overlap-partition.yaml
@@ -5,11 +5,11 @@ raw:
   - input-offset: 0
     output-offset: 33KiB
     input:
-      uri: random.bin
+      filename: random.bin
   - input-offset: 0
     output-offset: 16MiB
     input:
-      uri: random.bin
+      filename: random.bin
 
 partitions:
   - type: primary

--- a/tests/config/raw-overlap-raw.yaml
+++ b/tests/config/raw-overlap-raw.yaml
@@ -5,11 +5,11 @@ raw:
   - input-offset: 0
     output-offset: 1010KiB
     input:
-      uri: random.bin
+      filename: random.bin
   - input-offset: 0
     output-offset: 1MiB
     input:
-      uri: random.bin
+      filename: random.bin
 
 partitions:
   - type: primary

--- a/tests/config/system-tests/gpt.yaml
+++ b/tests/config/system-tests/gpt.yaml
@@ -5,7 +5,7 @@ raw:
   - output-offset: 17kiB
     input-offset: 0kiB
     input:
-      uri: random.bin
+      filename: random.bin
 
 partitions:
   - label: BOOT
@@ -14,14 +14,14 @@ partitions:
     size: 32MiB
     offset: 4MiB
     input:
-      - uri: lorem.txt
+      - filename: lorem.txt
   - label: ROOT1
     filesystem: ext4
     expand: true
     input:
-      - uri: lorem.tar
+      - filename: lorem.tar
   - label: ROOT
     filesystem: null
     expand: true
     input:
-      - uri: root.ext4
+      - filename: root.ext4

--- a/tests/config/system-tests/msdos.yaml
+++ b/tests/config/system-tests/msdos.yaml
@@ -5,7 +5,7 @@ raw:
   - output-offset: 1kiB
     input-offset: 1kiB
     input:
-      uri: random.bin
+      filename: random.bin
 
 partitions:
   - label: BOOT
@@ -15,16 +15,16 @@ partitions:
     flags:
       - boot
     input:
-      - uri: lorem.txt
+      - filename: lorem.txt
   - label: ROOT1
     filesystem: ext4
     expand: true
     input:
-      - uri: lorem.tar
+      - filename: lorem.tar
   - label: ROOT2
     type: logical
     filesystem: null
     block-size: 4kiB
     expand: true
     input:
-      - uri: root.ext4
+      - filename: root.ext4

--- a/tests/utils.c
+++ b/tests/utils.c
@@ -126,28 +126,19 @@ test_write_raw_input_offset(EmptyFileFixture *fixture,
 }
 
 static void
-test_path_from_uri(void)
+test_path_from_filename(void)
 {
     g_autoptr(GError) error = NULL;
-    g_autofree gchar *path = pu_path_from_uri("lorem.txt", "data", &error);
+    g_autofree gchar *path = pu_path_from_filename("lorem.txt", "data", &error);
     g_assert_no_error(error);
     g_assert_cmpstr("data/lorem.txt", ==, path);
 }
 
 static void
-test_path_from_uri_empty(void)
+test_path_from_filename_empty(void)
 {
     g_autoptr(GError) error = NULL;
-    g_autofree gchar *path = pu_path_from_uri("", "data", &error);
-    g_assert_error(error, PU_ERROR, PU_ERROR_FAILED);
-    g_assert_null(path);
-}
-
-static void
-test_path_from_uri_http(void)
-{
-    g_autoptr(GError) error = NULL;
-    g_autofree gchar *path = pu_path_from_uri("http://lorem.txt", "data", &error);
+    g_autofree gchar *path = pu_path_from_filename("", "data", &error);
     g_assert_error(error, PU_ERROR, PU_ERROR_FAILED);
     g_assert_null(path);
 }
@@ -240,9 +231,8 @@ main(int argc,
                test_write_raw, empty_file_tear_down);
     g_test_add("/utils/write_raw_input_offset", EmptyFileFixture, "file", empty_file_set_up,
                test_write_raw_input_offset, empty_file_tear_down);
-    g_test_add_func("/utils/path_from_uri", test_path_from_uri);
-    g_test_add_func("/utils/path_from_uri_empty", test_path_from_uri_empty);
-    g_test_add_func("/utils/path_from_uri_http", test_path_from_uri_http);
+    g_test_add_func("/utils/path_from_filename", test_path_from_filename);
+    g_test_add_func("/utils/path_from_filename_empty", test_path_from_filename_empty);
     g_test_add_func("/utils/device_get_partition_path_mmc",
                     test_device_get_partition_path_mmc);
     g_test_add_func("/utils/device_get_partition_path_sd",


### PR DESCRIPTION
Relative paths should not use the `file://` scheme so remove all uses of it.
Also remove the workaround that made using this scheme possible with file names.
