### PR TITLE
src: package: Allow any .yaml file as layout

### DIFF
--- a/doc/package.rst
+++ b/doc/package.rst
@@ -4,14 +4,13 @@ Package Format
 partup packages use the `SquashFS filesystem
 <https://github.com/plougher/squashfs-tools>`__ to provide a read-only image
 containing all required input files and the :doc:`layout configuration file
-<layout-config-reference>`. The layout configuration file must be named
-``layout.yaml`` and be placed at the root of the package. When using partup's
+<layout-config-reference>`. The layout configuration file must be the only
+``.yaml`` file and be placed at the root of the package. When using partup's
 builtin command ``package`` to create one, these requirements are automatically
 checked against.
 
 Creating a package is as easy as specifying an output filename for the package,
-its input files and the layout configuration file named exactly
-``layout.yaml``::
+its input files and the layout configuration file as the only ``.yaml`` file::
 
    partup package mypackage.partup u-boot.bin zImage rootfs.tar.gz layout.yaml
 

--- a/src/pu-package.h
+++ b/src/pu-package.h
@@ -18,14 +18,13 @@ typedef enum {
     PU_PACKAGE_ERROR_EXISTS,
     PU_PACKAGE_ERROR_ITER_FAILED,
     PU_PACKAGE_ERROR_MISSING_LAYOUT,
+    PU_PACKAGE_ERROR_MULTIPLE_LAYOUT,
     PU_PACKAGE_ERROR_NOT_FOUND,
     PU_PACKAGE_ERROR_FAILED
 } PuPackageError;
 
 #define PU_PACKAGE_BASENAME        "package"
-#define PU_PACKAGE_LAYOUT_BASENAME "layout.yaml"
 #define PU_PACKAGE_PREFIX          PU_MOUNT_PREFIX "/" PU_PACKAGE_BASENAME
-#define PU_PACKAGE_LAYOUT_FILE     PU_PACKAGE_PREFIX "/" PU_PACKAGE_LAYOUT_BASENAME
 
 gchar * pu_package_get_layout_file(const gchar *pwd,
                                    GError **error);


### PR DESCRIPTION
The layout configuration file does not need to be named 'layout.yaml' anymore. Any yaml file provided will be recognized as the layout. Providing none or multiple yaml files is an error. Also, update the doc accordingly.