### PR TITLE
github: workflows: documentation: Remove GitHub Pages deployment

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,9 +29,3 @@ jobs:
           pip install -r doc/requirements.txt
           meson setup build -Ddoc=true
           meson compile -C build doc
-      - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref_name == 'main' }}
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: build/doc/html


### PR DESCRIPTION
Do not deploy to GitHub Pages anymore, since we switched to Read the Docs. However keep the workflow building the documentation itself to test against build failures.

I will disable GitHub Pages for this project after this PR gets merged.