### PR TITLE
src: command: Allow passing command usage

### DIFF
--- a/src/pu-command.c
+++ b/src/pu-command.c
@@ -284,7 +284,7 @@ pu_command_context_parse(PuCommandContext *context,
          * that reason, add the main usage here. */
         GOptionEntry extra_entries[] = {
             { G_OPTION_REMAINING, 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING_ARRAY,
-                arg_remaining, "", "COMMAND" },
+                arg_remaining, NULL, "COMMAND" },
             { NULL }
         };
         g_option_context_add_main_entries(context->option_context,

--- a/src/pu-command.c
+++ b/src/pu-command.c
@@ -11,6 +11,7 @@ struct _PuCommandContext {
     PuCommandEntry *command;
     /* Additional arguments (null-terminated), not being commands or options */
     gchar **args;
+    gsize args_len;
 
     /* The option context to append options to */
     GOptionContext *option_context;
@@ -21,6 +22,9 @@ struct _PuCommandContext {
     /* All valid command entries */
     PuCommandEntry *entries;
     gsize entries_len;
+
+    /* If some input args were already parsed */
+    gboolean parsed;
 };
 
 G_DEFINE_QUARK(pu-command-context-error-quark, pu_command_error)
@@ -31,7 +35,8 @@ pu_command_context_new(void)
     PuCommandContext *context;
 
     context = g_new0(PuCommandContext, 1);
-    context->option_context = g_option_context_new("COMMAND");
+    context->option_context = g_option_context_new(NULL);
+    context->parsed = FALSE;
 
     return context;
 }
@@ -229,10 +234,13 @@ gboolean
 pu_command_context_parse(PuCommandContext *context,
                          gint *argc,
                          gchar ***argv,
+                         gchar ***arg_remaining,
                          GError **error)
 {
     g_return_val_if_fail(context != NULL, FALSE);
+    g_return_val_if_fail(arg_remaining != NULL && *arg_remaining == NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+    g_return_val_if_fail(!context->parsed, FALSE);
 
     if (!argc || !argv) {
         g_set_error(error, PU_COMMAND_ERROR, PU_COMMAND_ERROR_BAD_VALUE,
@@ -270,6 +278,17 @@ pu_command_context_parse(PuCommandContext *context,
     if (context->command && context->command->option_entries != NULL) {
         g_option_context_add_main_entries(context->option_context,
                                           context->command->option_entries, NULL);
+    } else {
+        /* Main option entries should not contain the G_OPTION_REMAINING, as it
+         * would override the one provided with the command specific one. For
+         * that reason, add the main usage here. */
+        GOptionEntry extra_entries[] = {
+            { G_OPTION_REMAINING, 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING_ARRAY,
+                arg_remaining, "", "COMMAND" },
+            { NULL }
+        };
+        g_option_context_add_main_entries(context->option_context,
+                                          extra_entries, NULL);
     }
 
     /* Parse main options and command-specific ones */
@@ -278,30 +297,29 @@ pu_command_context_parse(PuCommandContext *context,
         return FALSE;
     }
 
-    /* Consume first argument (program name) and second one (command name) and
-     * update argv accordingly */
-    for (gint i = 0; i < *argc - 2; i++) {
-        g_free((*argv)[i]);
-        (*argv)[i] = g_strdup((*argv)[i + 2]);
-    }
-    for (gint i = 0; i < 2; i++) {
-        g_free((*argv)[*argc - 1]);
-        (*argv)[*argc - 1] = NULL;
-        (*argc)--;
+    /* Retrieve remaining arguments */
+    context->args_len = g_strv_length(*arg_remaining) - 1;
+    context->args = g_malloc0((context->args_len + 1) * sizeof(gchar *));
+    if (context->args_len > 0) {
+        /* First remaining argument is the command, skip that one */
+        for (gsize i = 0; i < context->args_len; i++)
+            context->args[i] = g_strdup((*arg_remaining)[i + 1]);
     }
 
     /* Check for correct number of arguments depending on command type */
-    if ((*argc != 0 && context->command->arg == PU_COMMAND_ARG_NONE) ||
-        (*argc != 1 && context->command->arg == PU_COMMAND_ARG_FILENAME) ||
-        (*argc < 2 && context->command->arg == PU_COMMAND_ARG_FILENAME_ARRAY)) {
-        g_autofree gchar *excess_args = g_strjoinv(" ", *argv + 1);
+    if ((context->args_len != 0 && context->command->arg == PU_COMMAND_ARG_NONE) ||
+        (context->args_len != 1 && context->command->arg == PU_COMMAND_ARG_FILENAME) ||
+        (context->args_len < 2 && context->command->arg == PU_COMMAND_ARG_FILENAME_ARRAY)) {
+        g_autofree gchar *excess_args = NULL;
+        if (context->args)
+            excess_args = g_strjoinv(" ", context->args);
         g_set_error(error, PU_COMMAND_ERROR, PU_COMMAND_ERROR_BAD_VALUE,
-                    "Invalid number of arguments for command '%s'",
-                    context->command->name);
+                    "Invalid number of arguments (%ld) for command '%s': '%s'",
+                    context->args_len, context->command->name, excess_args);
         return FALSE;
     }
 
-    context->args = g_strdupv(*argv);
+    context->parsed = TRUE;
 
     return TRUE;
 }
@@ -309,16 +327,18 @@ pu_command_context_parse(PuCommandContext *context,
 gboolean
 pu_command_context_parse_strv(PuCommandContext *context,
                               gchar ***args,
+                              gchar ***arg_remaining,
                               GError **error)
 {
     gboolean res;
     gint argc;
 
     g_return_val_if_fail(context != NULL, FALSE);
+    g_return_val_if_fail(arg_remaining != NULL && *arg_remaining == NULL, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
     argc = args && *args ? g_strv_length(*args) : 0;
-    res = pu_command_context_parse(context, &argc, args, error);
+    res = pu_command_context_parse(context, &argc, args, arg_remaining, error);
 
     return res;
 }

--- a/src/pu-command.c
+++ b/src/pu-command.c
@@ -330,7 +330,6 @@ pu_command_context_parse_strv(PuCommandContext *context,
                               gchar ***arg_remaining,
                               GError **error)
 {
-    gboolean res;
     gint argc;
 
     g_return_val_if_fail(context != NULL, FALSE);
@@ -338,9 +337,8 @@ pu_command_context_parse_strv(PuCommandContext *context,
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
     argc = args && *args ? g_strv_length(*args) : 0;
-    res = pu_command_context_parse(context, &argc, args, arg_remaining, error);
 
-    return res;
+    return pu_command_context_parse(context, &argc, args, arg_remaining, error);
 }
 
 gboolean

--- a/src/pu-command.h
+++ b/src/pu-command.h
@@ -53,9 +53,11 @@ gchar ** pu_command_context_get_args(PuCommandContext *context);
 gboolean pu_command_context_parse(PuCommandContext *context,
                                   gint *argc,
                                   gchar ***argv,
+                                  gchar ***arg_remaining,
                                   GError **error);
 gboolean pu_command_context_parse_strv(PuCommandContext *context,
                                        gchar ***args,
+                                       gchar ***arg_remaining,
                                        GError **error);
 gboolean pu_command_context_invoke(PuCommandContext *context,
                                    GError **error);

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -238,10 +238,7 @@ main(G_GNUC_UNUSED int argc,
 {
     g_autoptr(GError) error = NULL;
     g_autoptr(PuCommandContext) context_cmd = NULL;
-    g_autoptr(GOptionContext) option_context = NULL;
     g_autofree gchar **args;
-    g_autofree gchar *default_cmd = NULL;
-    g_autofree gchar **main_args = NULL;
 
     /* Support unicode filenames */
     setlocale(LC_ALL, "");

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -28,6 +28,7 @@ static gboolean arg_install_skip_checksums = FALSE;
 static gchar *arg_package_directory = NULL;
 static gboolean arg_package_force = FALSE;
 static gboolean arg_show_size = FALSE;
+static gchar **arg_remaining = NULL;
 
 static inline gboolean
 error_not_root(GError **error)
@@ -190,6 +191,8 @@ static GOptionEntry option_entries_main[] = {
 static GOptionEntry option_entries_install[] = {
     { "skip-checksums", 's', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
         &arg_install_skip_checksums, "Skip checksum verification for all input files", NULL },
+    { G_OPTION_REMAINING, 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING_ARRAY,
+        &arg_remaining, NULL, "install PACKAGE DEVICE" },
     { NULL }
 };
 
@@ -198,12 +201,22 @@ static GOptionEntry option_entries_package[] = {
         &arg_package_directory, "Change to DIR before creating the package", "DIR" },
     { "force", 'f', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
         &arg_package_force, "Overwrite any existing package", NULL },
+    { G_OPTION_REMAINING, 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING_ARRAY,
+        &arg_remaining, NULL, "package PACKAGE FILES…" },
     { NULL }
 };
 
 static GOptionEntry option_entries_show[] = {
     { "size", 's', G_OPTION_FLAG_NONE, G_OPTION_ARG_NONE,
         &arg_show_size, "Print the size of each file", NULL },
+    { G_OPTION_REMAINING, 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING_ARRAY,
+        &arg_remaining, NULL, "show PACKAGE" },
+    { NULL }
+};
+
+static GOptionEntry option_entries_version[] = {
+    { G_OPTION_REMAINING, 0, G_OPTION_FLAG_NONE, G_OPTION_ARG_STRING_ARRAY,
+        &arg_remaining, NULL, "version" },
     { NULL }
 };
 
@@ -215,7 +228,7 @@ static PuCommandEntry command_entries[] = {
     { "show", PU_COMMAND_ARG_FILENAME, cmd_show,
         "List the contents of a package", option_entries_show },
     { "version", PU_COMMAND_ARG_NONE, cmd_version,
-        "Print the program version", NULL },
+        "Print the program version", option_entries_version },
     PU_COMMAND_ENTRY_NULL
 };
 
@@ -238,7 +251,7 @@ main(G_GNUC_UNUSED int argc,
 
     context_cmd = pu_command_context_new();
     pu_command_context_add_entries(context_cmd, command_entries, option_entries_main);
-    if (!pu_command_context_parse_strv(context_cmd, &args, &error)) {
+    if (!pu_command_context_parse_strv(context_cmd, &args, &arg_remaining, &error)) {
         g_critical("%s", error->message);
         return 1;
     }


### PR DESCRIPTION
Allow passing a command usage overview by using the special option entry `G_OPTION_REMAINING` and its argument description field.