### PR TITLE
src: emmc: Restructure MMC controls

### DIFF
--- a/doc/data/layout-ab-emmc.yaml
+++ b/doc/data/layout-ab-emmc.yaml
@@ -1,14 +1,15 @@
 api-version: 0
 disklabel: msdos
 
-emmc-boot-partitions:
-  enable: true
-  input-offset: 0
-  output-offset: 0
-  input:
-    filename: barebox.bin
-    md5sum: 46b1db79bc81e7af11b29436fb7a2515
-    sha256sum: a4d0b0802fc30fbdc987def1975f665190aa35af64fcd9dae26fc1b121c71966
+mmc:
+  boot-partitions:
+    enable: true
+    input-offset: 0
+    output-offset: 0
+    input:
+      filename: barebox.bin
+      md5sum: 46b1db79bc81e7af11b29436fb7a2515
+      sha256sum: a4d0b0802fc30fbdc987def1975f665190aa35af64fcd9dae26fc1b121c71966
 
 clean:
   - offset: 3840KiB

--- a/doc/layout-config-reference.rst
+++ b/doc/layout-config-reference.rst
@@ -93,26 +93,34 @@ options:
 ``input`` (sequence)
    A sequence of input mappings. See :ref:`input-files`.
 
-eMMC Specifics
---------------
+MMC Controls
+------------
+
+MMC specific controls can be specified using the keyword ``mmc`` containing a
+mapping of the following options:
+
+``boot-partitions`` (mapping)
+   An eMMC boot partitions mapping. See :ref:`boot-partitions`.
+
+.. _boot-partitions:
 
 eMMC Boot Partitions
 ....................
 
 eMMC's special boot partitions can be specified using the keyword
-``emmc-boot-partitions`` containing a mapping of the following options:
+``boot-partitions`` containing a mapping of the following options:
 
 ``enable`` (boolean)
    Enable the boot partitions.
 
 ``input-offset`` (integer/string)
-   Offset of the input data to be written.
+   Offset of the input data to be written. This keyword is optional.
 
 ``output-offset`` (integer/string)
-   Offset of the written output data.
+   Offset of the written output data. This keyword is optional.
 
 ``input`` (mapping)
-   An input mapping. See :ref:`input-files`.
+   An input mapping. See :ref:`input-files`. This keyword is optional.
 
 .. _input-files:
 

--- a/src/pu-emmc.c
+++ b/src/pu-emmc.c
@@ -408,7 +408,7 @@ pu_emmc_write_data(PuFlash *flash,
         PuEmmcBootPartitions *boot_partitions = NULL;
 
         boot_partitions = self->mmc_controls->boot_partitions;
-        if (boot_partitions) {
+        if (boot_partitions && pu_has_bootpart(self->device->path)) {
             PuEmmcInput *input = boot_partitions->input;
 
             if (!pu_bootpart_enable(self->device->path, boot_partitions->enable, error))

--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -254,6 +254,25 @@ pu_write_raw(const gchar *input_path,
     return TRUE;
 }
 
+gboolean
+pu_has_bootpart(const gchar *device)
+{
+    g_autofree gchar *path = NULL;
+    g_autoptr(GFile) file = NULL;
+
+    g_return_val_if_fail(g_strcmp0(device, "") > 0, 0);
+
+    for (guint i = 0; i <= 1; i++) {
+        path = g_strdup_printf("%sboot%u", device, i);
+        file = g_file_new_for_path(path);
+
+        if (!g_file_query_exists(file, NULL))
+            return FALSE;
+    }
+
+    return TRUE;
+}
+
 static gboolean
 pu_bootpart_force_ro(const gchar *bootpart,
                      gboolean read_only,

--- a/src/pu-utils.h
+++ b/src/pu-utils.h
@@ -29,6 +29,7 @@ gboolean pu_write_raw(const gchar *input_path,
                       PedSector output_offset,
                       PedSector size,
                       GError **error);
+gboolean pu_has_bootpart(const gchar *device);
 gboolean pu_write_raw_bootpart(const gchar *input,
                                PedDevice *device,
                                guint bootpart,


### PR DESCRIPTION
Restructure the way eMMC boot partitions are specified in the layout configuration, so other MMC controls can be added in the future. Make the input for eMMC boot partitions optional, allowing to disable them without any input.