### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,42 @@
+.. _release-1.0.0:
+
+1.0.0
+=====
+
+*Release date: 2023-11-28*
+
+.. rubric:: Changes
+
+-  Host partup's documentation on readthedocs.org.
+-  Add usage description for all commands.
+-  The layout configuration file does not need to be named ``layout.yaml``
+   anymore. Any yaml file provided will be recognized as the layout.
+-  Rename the input uri to filename as all files are provided in a package and
+   therefore only need a relative path.
+-  Set the filesystem label after writing raw ext[234] partition. This
+   overwrites the label of the provided filesystem unless label is set to null.
+-  Restructure the way eMMC boot partitions are specified in the layout
+   configuration, so other MMC controls can be added in the future. Make the
+   input for eMMC boot partitions optional, allowing to disable them without any
+   input.
+-  Only write eMMC boot partitions if they actually exist. SD cards do not
+   support eMMC boot partitions, so they should be ignored for this option.
+-  Allow setting the eMMC boot partition to be enabled by its number.
+   Previously, only a boolean value was allowed, but now it is possible to
+   specify the exact boot partition to enable.
+-  Multiple binaries for the eMMC boot partitions can now be specified. Each
+   with their own input and output offset.
+
+.. rubric:: Bug Fixes
+
+-  Set LABEL for supported filesystems during filesystem creation. Previously
+   only PARTLABEL would be set, but this is only supported with GPT.
+
+.. rubric:: Contributors
+
+`Martin Schwan <https://github.com/mschwan-phytec>`__,
+`Leonard Anderweit <https://github.com/landerweit-phytec>`__
+
 .. _release-0.4.0:
 
 0.4.0

--- a/README.rst
+++ b/README.rst
@@ -13,12 +13,6 @@ partup - System Initialization Program
    :target: https://partup.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
-+------+------------------------------------------------------------------+
-| NOTE | *partup* is in "beta" state and not yet considered stable. The   |
-|      | configuration API may change without notice. Other parts of the  |
-|      | program may also change drastically until release version 1.0.0. |
-+------+------------------------------------------------------------------+
-
 Dependencies
 ============
 

--- a/doc/data/layout-ab-emmc.yaml
+++ b/doc/data/layout-ab-emmc.yaml
@@ -1,4 +1,4 @@
-api-version: 0
+api-version: 1
 disklabel: msdos
 
 mmc:

--- a/doc/data/layout-simple.yaml
+++ b/doc/data/layout-simple.yaml
@@ -1,4 +1,4 @@
-api-version: 0
+api-version: 1
 disklabel: msdos
 
 raw:

--- a/doc/layout-config-reference.rst
+++ b/doc/layout-config-reference.rst
@@ -11,8 +11,8 @@ API Version
 
    This scalar is mandatory.
 
-MMC Options
------------
+Disk Options
+------------
 
 ``disklabel`` (string)
    Partition table for the device. Currently supported options are ``msdos``

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
   'partup', 'c',
-  version : '0.4.0',
+  version : '1.0.0',
   license : 'GPL-3.0-or-later',
   default_options : [
     'c_std=c99',

--- a/src/pu-config.c
+++ b/src/pu-config.c
@@ -415,12 +415,23 @@ pu_config_new_from_file(const gchar *filename,
     return g_steal_pointer(&config);
 }
 
-gint
-pu_config_get_api_version(PuConfig *config)
+gboolean
+pu_config_is_version_compatible(PuConfig *config,
+                                gint version,
+                                GError **error)
 {
     PuConfigPrivate *priv = pu_config_get_instance_private(config);
 
-    return priv->api_version;
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    if (priv->api_version > version || priv->api_version == 0) {
+        g_set_error(error, PU_ERROR, PU_ERROR_FAILED,
+                    "API version %d of configuration file is not compatible "
+                    "with program version %d", priv->api_version, version);
+        return FALSE;
+    }
+
+    return TRUE;
 }
 
 GHashTable *

--- a/src/pu-config.h
+++ b/src/pu-config.h
@@ -55,14 +55,9 @@ typedef struct {
 PuConfig * pu_config_new_from_file(const gchar *filename,
                                    GError **error);
 
-/**
- * Get the API version specified in the configuration.
- *
- * @param self the configuration instance containing the API version.
- *
- * @return the API version number.
- */
-gint pu_config_get_api_version(PuConfig *config);
+gboolean pu_config_is_version_compatible(PuConfig *config,
+                                         gint version,
+                                         GError **error);
 
 GHashTable * pu_config_get_root(PuConfig *config);
 

--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -56,7 +56,6 @@ cmd_install(PuCommandContext *context,
     g_autofree gchar *device_path = NULL;
     g_autoptr(PuEmmc) emmc = NULL;
     gchar **args;
-    gint api_version;
     gboolean is_mounted;
 
     if (getuid() != 0)
@@ -98,13 +97,8 @@ cmd_install(PuCommandContext *context,
                        config_path);
         return error_out(mount_path);
     }
-    api_version = pu_config_get_api_version(config);
-    if (api_version > PARTUP_VERSION_MAJOR) {
-        g_set_error(error, PU_ERROR, PU_ERROR_FAILED,
-                    "API version %d of configuration file is not compatible "
-                    "with program version %d", api_version, PARTUP_VERSION_MAJOR);
+    if (!pu_config_is_version_compatible(config, PARTUP_VERSION_MAJOR, error))
         return error_out(mount_path);
-    }
 
     emmc = pu_emmc_new(device_path, config, mount_path,
                        arg_install_skip_checksums, error);

--- a/tests/config.c
+++ b/tests/config.c
@@ -20,6 +20,7 @@ config_simple(void)
 
     config = pu_config_new_from_file("config/simple.yaml", &error);
     g_assert_nonnull(config);
+    g_assert_false(pu_config_is_version_compatible(config, 0, NULL));
     g_assert_true(pu_config_is_version_compatible(config, 1, &error));
     root = pu_config_get_root(config);
     g_assert_nonnull(root);

--- a/tests/config.c
+++ b/tests/config.c
@@ -20,7 +20,7 @@ config_simple(void)
 
     config = pu_config_new_from_file("config/simple.yaml", &error);
     g_assert_nonnull(config);
-    g_assert_cmpint(pu_config_get_api_version(config), ==, 0);
+    g_assert_true(pu_config_is_version_compatible(config, 1, &error));
     root = pu_config_get_root(config);
     g_assert_nonnull(root);
     value = g_hash_table_lookup(root, "disklabel");

--- a/tests/config/raw-non-overlap.yaml
+++ b/tests/config/raw-non-overlap.yaml
@@ -1,4 +1,4 @@
-api-version: 0
+api-version: 1
 disklabel: gpt
 
 raw:

--- a/tests/config/raw-overlap-partition-table.yaml
+++ b/tests/config/raw-overlap-partition-table.yaml
@@ -1,4 +1,4 @@
-api-version: 0
+api-version: 1
 disklabel: gpt
 
 raw:

--- a/tests/config/raw-overlap-partition.yaml
+++ b/tests/config/raw-overlap-partition.yaml
@@ -1,4 +1,4 @@
-api-version: 0
+api-version: 1
 disklabel: gpt
 
 raw:

--- a/tests/config/raw-overlap-raw.yaml
+++ b/tests/config/raw-overlap-raw.yaml
@@ -1,4 +1,4 @@
-api-version: 0
+api-version: 1
 disklabel: gpt
 
 raw:

--- a/tests/config/simple.yaml
+++ b/tests/config/simple.yaml
@@ -1,4 +1,4 @@
-api-version: 0
+api-version: 1
 disklabel: msdos
 partitions:
   - label: BOOT

--- a/tests/config/system-tests/gpt.yaml
+++ b/tests/config/system-tests/gpt.yaml
@@ -1,4 +1,4 @@
-api-version: 0
+api-version: 1
 disklabel: gpt
 
 raw:

--- a/tests/config/system-tests/msdos.yaml
+++ b/tests/config/system-tests/msdos.yaml
@@ -1,4 +1,4 @@
-api-version: 0
+api-version: 1
 disklabel: msdos
 
 raw:


### PR DESCRIPTION
Add a function checking the API version of the configuration file against the current program version and return whether these are compatible. Development versions are considered never to be compatible with stable versions, as development versions broke the API too often.

Add release notes for version 1.0.0.