### PR TITLE
README: Note runtime dependency on dosfstools and e2fsprogs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,8 @@ The following tools and libraries must be installed on the target system for
 -  `util-linux <https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git>`_
 -  `udev <https://git.kernel.org/pub/scm/linux/hotplug/udev.git>`_
 -  `squashfs-tools <https://github.com/plougher/squashfs-tools>`_
+-  `dosfstools <https://github.com/dosfstools/dosfstools>`_
+-  `e2fsprogs <https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git>`_
 
 For building *partup* from source and generating its documentation the following
 additional dependencies are needed:


### PR DESCRIPTION
These tools are required for fat and ext[234] filesystem creation.