### PR TITLE
src: package: Print layout configuration

### DIFF
--- a/src/pu-main.c
+++ b/src/pu-main.c
@@ -159,7 +159,7 @@ cmd_show(PuCommandContext *context,
 
     args = pu_command_context_get_args(context);
 
-    return pu_package_list_contents(args[0], arg_show_size, error);
+    return pu_package_show_contents(args[0], arg_show_size, error);
 }
 
 static gboolean

--- a/src/pu-package.c
+++ b/src/pu-package.c
@@ -202,7 +202,7 @@ print_dir_content(GFile *dir,
 }
 
 gboolean
-pu_package_list_contents(const gchar *package,
+pu_package_show_contents(const gchar *package,
                          gboolean print_size,
                          GError **error)
 {

--- a/src/pu-package.h
+++ b/src/pu-package.h
@@ -32,7 +32,7 @@ gboolean pu_package_create(gchar **files,
                            const gchar *output,
                            gboolean force_overwrite,
                            GError **error);
-gboolean pu_package_list_contents(const gchar *package,
+gboolean pu_package_show_contents(const gchar *package,
                                   gboolean print_size,
                                   GError **error);
 gboolean pu_package_mount(const gchar *package,

--- a/tests/package-root.c
+++ b/tests/package-root.c
@@ -12,7 +12,7 @@
 #define PACKAGE_FILENAME "package.partup"
 
 static void
-package_list_contents(PackageFilesFixture *fixture,
+package_show_contents(PackageFilesFixture *fixture,
                       G_GNUC_UNUSED gconstpointer user_data)
 {
     g_autoptr(GFile) package_file = NULL;
@@ -22,7 +22,7 @@ package_list_contents(PackageFilesFixture *fixture,
     g_assert(pu_package_create(fixture->input_files, PACKAGE_FILENAME, FALSE, &fixture->error));
     g_assert_no_error(fixture->error);
 
-    g_assert(pu_package_list_contents(PACKAGE_FILENAME, TRUE, &fixture->error));
+    g_assert(pu_package_show_contents(PACKAGE_FILENAME, TRUE, &fixture->error));
     g_assert_no_error(fixture->error);
 
     package_file = g_file_new_build_filename(fixture->path_tmp, PACKAGE_FILENAME, NULL);
@@ -76,8 +76,8 @@ main(int argc,
     g_chdir(PARTUP_TEST_SRCDIR);
 #endif
 
-    g_test_add("/package/list-contents", PackageFilesFixture, NULL,
-               package_files_setup, package_list_contents, package_files_teardown);
+    g_test_add("/package/show_contents", PackageFilesFixture, NULL,
+               package_files_setup, package_show_contents, package_files_teardown);
     g_test_add("/package/mount", PackageFilesFixture, NULL,
                package_files_setup, package_mount, package_files_teardown);
 


### PR DESCRIPTION
Print the layout configuration of the package in addition to the package files. When printing the layout configuration, remove any empty lines in the output for better readability.

Rename `pu_package_list_contents()` to `pu_package_show_contents()` as the function now also shows the layout configuration, not just the list of files in the package.