### PR TITLE
Add layout config to specify eMMC boot ack

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@
 
 *Release date: TBD*
 
+.. rubric:: Changes
+
+-  Allow setting eMMC boot acknowledge.
+
 .. _release-1.0.0:
 
 1.0.0

--- a/doc/layout-config-reference.rst
+++ b/doc/layout-config-reference.rst
@@ -116,6 +116,12 @@ eMMC's special boot partitions can be specified using the keyword
 ``enable`` (integer)
    Enable and select the boot partition. 0 to disable boot partitions.
 
+``boot-ack`` (boolean)
+   Set the boot acknowledge property of the eMMC. The default value is
+   ``false``.
+
+   Available since: :ref:`release-2.0.0`
+
 ``binaries`` (sequence)
    A sequence of binaries to copy to the boot partitions. See :ref:`binaries`.
    This keyword is optional.

--- a/src/pu-emmc.c
+++ b/src/pu-emmc.c
@@ -44,6 +44,7 @@ typedef struct _PuEmmcBinary {
 } PuEmmcBinary;
 typedef struct _PuEmmcBootPartitions {
     guint enable;
+    gboolean boot_ack;
     GList *input;
 } PuEmmcBootPartitions;
 typedef struct _PuEmmcControls {
@@ -413,7 +414,8 @@ pu_emmc_write_data(PuFlash *flash,
         if (boot_partitions && pu_has_bootpart(self->device->path)) {
             GList *input = boot_partitions->input;
 
-            if (!pu_bootpart_enable(self->device->path, boot_partitions->enable, error))
+            if (!pu_bootpart_enable(self->device->path, boot_partitions->enable,
+                                    boot_partitions->boot_ack, error))
                 return FALSE;
 
             for (GList *i = input; i != NULL; i = i->next) {
@@ -596,9 +598,12 @@ pu_emmc_parse_mmc_controls(PuEmmc *emmc,
     emmc->mmc_controls->boot_partitions = g_new0(PuEmmcBootPartitions, 1);
     emmc->mmc_controls->boot_partitions->enable =
         pu_hash_table_lookup_int64(bootpart, "enable", 0);
+    emmc->mmc_controls->boot_partitions->boot_ack =
+        pu_hash_table_lookup_boolean(bootpart, "boot-ack", FALSE);
 
-    g_debug("Parsed bootpart: enable=%d",
-            emmc->mmc_controls->boot_partitions->enable);
+    g_debug("Parsed bootpart: enable=%d boot-ack=%s",
+            emmc->mmc_controls->boot_partitions->enable,
+            emmc->mmc_controls->boot_partitions->boot_ack ? "true" : "false");
 
     GList *input_list = pu_hash_table_lookup_list(bootpart, "binaries", NULL);
     for (GList *b = input_list; b != NULL; b = b->next) {

--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -368,6 +368,7 @@ pu_write_raw_bootpart(const gchar *input,
 gboolean
 pu_bootpart_enable(const gchar *device,
                    guint bootpart,
+                   gboolean boot_ack,
                    GError **error)
 {
     g_autofree gchar *cmd = NULL;
@@ -376,7 +377,7 @@ pu_bootpart_enable(const gchar *device,
     g_return_val_if_fail(bootpart <= 2, FALSE);
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-    cmd = g_strdup_printf("mmc bootpart enable %u 0 %s", bootpart, device);
+    cmd = g_strdup_printf("mmc bootpart enable %u %d %s", bootpart, boot_ack, device);
 
     return pu_spawn_command_line_sync(cmd, error);
 }

--- a/src/pu-utils.h
+++ b/src/pu-utils.h
@@ -42,6 +42,7 @@ gboolean pu_write_raw_bootpart(const gchar *input,
                                GError **error);
 gboolean pu_bootpart_enable(const gchar *device,
                             guint bootpart,
+                            gboolean boot_ack,
                             GError **error);
 gboolean pu_partition_set_partuuid(const gchar *device,
                                    guint index,


### PR DESCRIPTION
The eMMC boot ack is required for the TI am6xx SoCs.