### PR TITLE
CHANGELOG: Add skeleton for release 1.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+.. _release-1.1.0:
+
+1.1.0
+=====
+
+*Release date: TBD*
+
 .. _release-1.0.0:
 
 1.0.0


### PR DESCRIPTION
Add a skeleton for release 1.1.0, so it can be referenced in the documentation.