### PR TITLE
Add support for FAT16 filesystem type

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,7 +13,7 @@ Main Features
 -  Partitioning block devices
 -  Automatic partition size calculation to use whole device
 -  Supported disklabels: ``gpt``, ``msdos``
--  Supported filesystems: ``fat32``, ``ext2``, ``ext3``, ``ext4``
+-  Supported filesystems: ``fat16``, ``fat32``, ``ext2``, ``ext3``, ``ext4``
 -  Support for eMMC boot partitions
 -  Write files and extract archives to partitions
 -  Write raw binaries to device at specified offset

--- a/doc/layout-config-reference.rst
+++ b/doc/layout-config-reference.rst
@@ -69,7 +69,7 @@ options:
    logical, too. Logical partitions are only supported with the ``msdos``
    partition table.
 
-``filessytem`` (string)
+``filesystem`` (string)
    The filesystem type to use during formatting of the partition, e.g. ``fat32``
    or ``ext4``.
 

--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -114,8 +114,10 @@ pu_make_filesystem(const gchar *part,
 
     cmd = g_string_new(NULL);
 
-    if (g_strcmp0(fstype, "fat32") == 0) {
-        g_string_append(cmd, "mkfs.vfat ");
+    if (g_strcmp0(fstype, "fat16") == 0) {
+        g_string_append(cmd, "mkfs.fat -F 16 ");
+    } else if (g_strcmp0(fstype, "fat32") == 0) {
+        g_string_append(cmd, "mkfs.fat -F 32 ");
     } else if (g_strcmp0(fstype, "ext2") == 0) {
         g_string_append(cmd, "mkfs.ext2 ");
     } else if (g_strcmp0(fstype, "ext3") == 0) {
@@ -132,7 +134,7 @@ pu_make_filesystem(const gchar *part,
     }
 
     if (g_strcmp0(fstype, "") > 0) {
-        if (g_strcmp0(fstype, "fat32") == 0) {
+        if (g_regex_match_simple("^fat(16|32)$", fstype, 0, 0)) {
             g_string_append_printf(cmd, "-n \"%s\" ", label);
         } else if (g_regex_match_simple("^ext[234]$", fstype, 0, 0)) {
             g_string_append_printf(cmd, "-L \"%s\" ", label);

--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -133,7 +133,7 @@ pu_make_filesystem(const gchar *part,
         return FALSE;
     }
 
-    if (g_strcmp0(fstype, "") > 0) {
+    if (g_strcmp0(label, "") > 0) {
         if (g_regex_match_simple("^fat(16|32)$", fstype, 0, 0)) {
             g_string_append_printf(cmd, "-n \"%s\" ", label);
         } else if (g_regex_match_simple("^ext[234]$", fstype, 0, 0)) {


### PR DESCRIPTION
Add support for the FAT16 filesystem type. Explicitly mention the FAT size when calling mkfs. Run mkfs.fat instead of mkfs.vfat, as the latter is really just a symbolic link to the former.

Check against an empty label in `pu_make_filesystem()` instead of an empty fstype. The fstype check is done previously anyway, and we want to guard against null labels before appending anything.

Fix typo of filesystem type.