### PR TITLE
Allow passing extra args to mkfs

### DIFF
--- a/doc/layout-config-reference.rst
+++ b/doc/layout-config-reference.rst
@@ -73,6 +73,14 @@ options:
    The filesystem type to use during formatting of the partition, e.g. ``fat32``
    or ``ext4``.
 
+``mkfs-extra-args`` (string)
+   Extra arguments to be passed to mkfs. Note, that the allowed arguments may be
+   different, depending on the used filesystem type. See the man page of mkfs
+   with the particular filesystem to read up allowed arguments, e.g. ``man
+   mkfs.fat``.
+
+   Available since: :ref:`release-2.0.0`
+
 ``size`` (integer/string)
    The size of the partition.
 

--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -105,6 +105,7 @@ gboolean
 pu_make_filesystem(const gchar *part,
                    const gchar *fstype,
                    const gchar *label,
+                   const gchar *extra_args,
                    GError **error)
 {
     g_autoptr(GString) cmd = NULL;
@@ -137,6 +138,10 @@ pu_make_filesystem(const gchar *part,
         } else if (g_regex_match_simple("^ext[234]$", fstype, 0, 0)) {
             g_string_append_printf(cmd, "-L \"%s\" ", label);
         }
+    }
+
+    if (g_strcmp0(extra_args, "") > 0) {
+        g_string_append_printf(cmd, "%s ", extra_args);
     }
 
     g_string_append(cmd, part);

--- a/src/pu-utils.h
+++ b/src/pu-utils.h
@@ -20,6 +20,7 @@ gboolean pu_archive_extract(const gchar *filename,
 gboolean pu_make_filesystem(const gchar *part,
                             const gchar *type,
                             const gchar *label,
+                            const gchar *extra_args,
                             GError **error);
 gboolean pu_set_ext_label(const gchar *part,
                           const gchar *label,

--- a/tests/helper.c
+++ b/tests/helper.c
@@ -47,8 +47,8 @@ create_partition(const gchar *device,
     g_assert_true(pu_wait_for_partitions(error));
     g_assert_no_error(*error);
 
-    g_assert_true(pu_make_filesystem(g_strdup_printf("%sp1", device),
-                                     "ext4", "", error));
+    g_assert_true(pu_make_filesystem(g_strdup_printf("%sp1", device), "ext4",
+                                     "", NULL, error));
     g_assert_no_error(*error);
 }
 

--- a/tests/utils.c
+++ b/tests/utils.c
@@ -81,7 +81,7 @@ test_make_filesystem(EmptyFileFixture *fixture,
     gint wait_status;
 
     g_assert_true(pu_make_filesystem(g_file_get_path(fixture->file), "ext4",
-                  "test", &fixture->error));
+                  "test", NULL, &fixture->error));
     g_assert_no_error(fixture->error);
 
     cmd = g_strdup_printf("blkid -o value -s TYPE %s", g_file_get_path(fixture->file));
@@ -108,7 +108,7 @@ test_set_ext_label(EmptyFileFixture *fixture,
     gint wait_status;
 
     g_assert_true(pu_make_filesystem(g_file_get_path(fixture->file), "ext4",
-                  "", &fixture->error));
+                  "", NULL, &fixture->error));
     g_assert_no_error(fixture->error);
 
     g_assert_true(pu_set_ext_label(g_file_get_path(fixture->file), "test",


### PR DESCRIPTION
Allow passing extra arguments when making the filesystem on a partition.

Do not pass any extra arguments to `pu_make_filesystem()` relevant for mkfs.

Describe the partition option "mkfs-extra-args" and how to use it.