### PR TITLE
src: emmc: Verify checksum of written raw output data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+.. _release-2.1.0:
+
+2.1.0
+=====
+
+*Release date: TBD*
+
 .. _release-2.0.0:
 
 2.0.0

--- a/doc/layout-config-reference.rst
+++ b/doc/layout-config-reference.rst
@@ -37,6 +37,9 @@ Raw Data
 The section ``raw`` contains a sequence of mappings describing data that is
 written outside of partitions. Each entry may contain the following options:
 
+Since :ref:`release-2.1.0`, the written output is also being verified by
+checking against the input's SHA256 sum, including any given offsets.
+
 ``input-offset`` (integer/string)
    Offset of the input data to be written.
 

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,7 @@ src = [
   'src/pu-config.c',
   'src/pu-emmc.c',
   'src/pu-error.c',
+  'src/pu-file.c',
   'src/pu-flash.c',
   'src/pu-glib-compat.c',
   'src/pu-hashtable.c',

--- a/src/pu-checksum.c
+++ b/src/pu-checksum.c
@@ -19,7 +19,7 @@ pu_checksum_verify_file(const gchar *filename,
     g_autoptr(GFileInfo) file_info = NULL;
     goffset file_size;
     g_autofree guchar *buffer = NULL;
-    g_autoptr(GChecksum) checksum_obj = NULL;
+    g_autofree gchar *computed_checksum = NULL;
 
     g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
@@ -38,13 +38,11 @@ pu_checksum_verify_file(const gchar *filename,
                                  NULL, NULL, error))
         return FALSE;
 
-    checksum_obj = g_checksum_new(checksum_type);
-    g_checksum_update(checksum_obj, buffer, file_size);
-
-    if (!g_str_equal(checksum, g_checksum_get_string(checksum_obj))) {
+    computed_checksum = g_compute_checksum_for_data(checksum_type, buffer, file_size);
+    if (!g_str_equal(checksum, computed_checksum)) {
         g_set_error(error, PU_ERROR, PU_ERROR_CHECKSUM,
-                    "Given checksum '%s' of file '%s' does not match",
-                    checksum, filename);
+                    "Given checksum '%s' of file '%s' does not match '%s'",
+                    checksum, filename, computed_checksum);
         return FALSE;
     }
 

--- a/src/pu-checksum.h
+++ b/src/pu-checksum.h
@@ -13,5 +13,15 @@ gboolean pu_checksum_verify_file(const gchar *filename,
                                  const gchar *checksum,
                                  GChecksumType checksum_type,
                                  GError **error);
+gboolean pu_checksum_verify_raw(const gchar *filename,
+                                goffset offset,
+                                gsize size,
+                                const gchar *checksum,
+                                GChecksumType checksum_type,
+                                GError **error);
+gchar * pu_checksum_new_from_file(const gchar *filename,
+                                  goffset offset,
+                                  GChecksumType checksum_type,
+                                  GError **error);
 
 #endif /* PARTUP_CHECKSUM_H */

--- a/src/pu-file.c
+++ b/src/pu-file.c
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2024 PHYTEC Messtechnik GmbH
+ */
+
+#include <gio/gio.h>
+#include "pu-error.h"
+#include "pu-file.h"
+
+gboolean
+pu_file_read_raw(const gchar *filename,
+                 guchar **buffer,
+                 goffset offset,
+                 gssize count,
+                 gsize *bytes_read,
+                 GError **error)
+{
+    g_autoptr(GFile) file = g_file_new_for_path(filename);
+    g_autoptr(GFileInputStream) stream = NULL;
+    g_autoptr(GFileInfo) file_info = NULL;
+    goffset file_size;
+
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    stream = g_file_read(file, NULL, error);
+    if (stream == NULL)
+        return FALSE;
+
+    file_info = g_file_query_info(file, G_FILE_ATTRIBUTE_STANDARD_SIZE,
+                                  G_FILE_QUERY_INFO_NONE, NULL, error);
+    if (file_info == NULL)
+        return FALSE;
+
+    file_size = g_file_info_get_size(file_info);
+    if (count < 0)
+        count = file_size - offset;
+
+    if (g_input_stream_skip(G_INPUT_STREAM(stream), offset, NULL, error) < 0)
+        return FALSE;
+
+    *buffer = g_new0(guchar, count);
+    if (!g_input_stream_read_all(G_INPUT_STREAM(stream), *buffer, count,
+                                 bytes_read, NULL, error))
+        return FALSE;
+
+    return TRUE;
+}

--- a/src/pu-file.h
+++ b/src/pu-file.h
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2024 PHYTEC Messtechnik GmbH
+ */
+
+#ifndef PARTUP_FILE_H
+#define PARTUP_FILE_H
+
+#include <glib.h>
+
+gboolean pu_file_read_raw(const gchar *filename,
+                          guchar **buffer,
+                          goffset offset,
+                          gssize count,
+                          gsize *bytes_read,
+                          GError **error);
+
+#endif /* PARTUP_FILE_H */

--- a/tests/checksum.c
+++ b/tests/checksum.c
@@ -11,6 +11,8 @@
 
 #define LOREM_TXT_SHA256SUM "25623b53e0984428da972f4c635706d32d01ec92dcd2ab39066082e0b9488c9d"
 #define LOREM_TXT_MD5SUM    "3bc34a45d26784b5bea8529db533ae84"
+#define RANDOM_BIN_1024_3072_SHA256SUM "e8f899417ccad9ca2d4a49057aed9b9c1e0998d29434006ce0130d180d76e90d"
+#define RANDOM_BIN_1024_3072_MD5SUM    "c231ac1b4f0ed9efbc485310de58bc3d"
 
 static void
 checksum_good(void)
@@ -23,6 +25,15 @@ checksum_good(void)
 
     g_assert_true(pu_checksum_verify_file("data/lorem.txt", LOREM_TXT_MD5SUM,
                                           G_CHECKSUM_MD5, &error));
+    g_assert_no_error(error);
+
+    g_assert_true(pu_checksum_verify_raw("data/random.bin", 1024, 3072,
+                                         RANDOM_BIN_1024_3072_SHA256SUM,
+                                         G_CHECKSUM_SHA256, &error));
+    g_assert_no_error(error);
+    g_assert_true(pu_checksum_verify_raw("data/random.bin", 1024, 3072,
+                                         RANDOM_BIN_1024_3072_MD5SUM,
+                                         G_CHECKSUM_MD5, &error));
     g_assert_no_error(error);
 }
 
@@ -41,10 +52,40 @@ checksum_bad(void)
     g_assert_error(error, PU_ERROR, PU_ERROR_CHECKSUM);
     g_clear_error(&error);
 
+    g_assert_false(pu_checksum_verify_raw("data/random.bin", 0, 2048, "",
+                                          G_CHECKSUM_SHA256, &error));
+    g_assert_error(error, PU_ERROR, PU_ERROR_CHECKSUM);
+    g_clear_error(&error);
+
+    g_assert_false(pu_checksum_verify_raw("data/random.bin", 0, 2048, "",
+                                          G_CHECKSUM_MD5, &error));
+    g_assert_error(error, PU_ERROR, PU_ERROR_CHECKSUM);
+    g_clear_error(&error);
+
     g_assert_false(pu_checksum_verify_file("file/not/found", "",
                                            G_CHECKSUM_MD5, &error));
     g_assert_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
     g_clear_error(&error);
+
+    g_assert_false(pu_checksum_verify_raw("file/not/found", 0, 2048, "",
+                                          G_CHECKSUM_MD5, &error));
+    g_assert_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+    g_clear_error(&error);
+}
+
+static void
+checksum_creation(void)
+{
+    g_autoptr(GError) error = NULL;
+    g_autofree gchar *checksum = NULL;
+
+    checksum = pu_checksum_new_from_file("data/lorem.txt", 0, G_CHECKSUM_SHA256, &error);
+    g_assert_no_error(error);
+    g_assert_cmpstr(checksum, ==, LOREM_TXT_SHA256SUM);
+
+    checksum = pu_checksum_new_from_file("data/lorem.txt", 0, G_CHECKSUM_MD5, &error);
+    g_assert_no_error(error);
+    g_assert_cmpstr(checksum, ==, LOREM_TXT_MD5SUM);
 }
 
 int
@@ -59,6 +100,7 @@ main(int argc,
 
     g_test_add_func("/checksum/good", checksum_good);
     g_test_add_func("/checksum/bad", checksum_bad);
+    g_test_add_func("/checksum/creation", checksum_creation);
 
     return g_test_run();
 }


### PR DESCRIPTION
For raw data only, verify the written output data, in addition to the already existing input verification.

First, a checksum is created of the input file while accounting any input offset. Then the data is written as usual to the device. Finally, the written data is verified at the specified output offset against the previously determined checksum.