### PR TITLE
src: pu-file: Move more file related functions

### DIFF
--- a/src/pu-emmc.c
+++ b/src/pu-emmc.c
@@ -9,6 +9,7 @@
 #include <glib/gstdio.h>
 #include "pu-checksum.h"
 #include "pu-error.h"
+#include "pu-file.h"
 #include "pu-hashtable.h"
 #include "pu-mount.h"
 #include "pu-utils.h"
@@ -392,7 +393,7 @@ pu_emmc_write_data(PuFlash *flash,
             continue;
         }
 
-        size = pu_get_file_size(path, error);
+        size = pu_file_get_size(path, error);
         if (size == 0) {
             g_prefix_error(error, "Failed retrieving file size for binary: ");
             return FALSE;
@@ -785,7 +786,7 @@ pu_emmc_parse_raw(PuEmmc *emmc,
         if (path == NULL)
             return FALSE;
 
-        input->_size = pu_get_file_size(path, error);
+        input->_size = pu_file_get_size(path, error);
         if (!input->_size)
             return FALSE;
 

--- a/src/pu-file.c
+++ b/src/pu-file.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2024 PHYTEC Messtechnik GmbH
  */
 
+#define G_LOG_DOMAIN "partup-file"
+
 #include <gio/gio.h>
 #include "pu-error.h"
 #include "pu-file.h"
@@ -44,4 +46,45 @@ pu_file_read_raw(const gchar *filename,
         return FALSE;
 
     return TRUE;
+}
+
+gboolean
+pu_file_copy(const gchar *src,
+             const gchar *dest,
+             GError **error)
+{
+    g_autoptr(GFile) in = NULL;
+    g_autofree gchar *out_path = NULL;
+    g_autoptr(GFile) out = NULL;
+
+    g_return_val_if_fail(src != NULL, FALSE);
+    g_return_val_if_fail(dest != NULL, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    g_debug("Copying '%s' to '%s'", src, dest);
+
+    in = g_file_new_for_path(src);
+    out_path = g_build_filename(dest, g_path_get_basename(src), NULL);
+    out = g_file_new_for_path(out_path);
+
+    return g_file_copy(in, out, G_FILE_COPY_NONE, NULL, NULL, NULL, error);
+}
+
+goffset
+pu_file_get_size(const gchar *path,
+                 GError **error)
+{
+    g_autoptr(GFile) file = NULL;
+    g_autoptr(GFileInfo) file_info = NULL;
+
+    g_return_val_if_fail(g_strcmp0(path, "") > 0, 0);
+    g_return_val_if_fail(error == NULL || *error == NULL, 0);
+
+    file = g_file_new_for_path(path);
+    file_info = g_file_query_info(file, G_FILE_ATTRIBUTE_STANDARD_SIZE,
+                                  G_FILE_QUERY_INFO_NONE, NULL, error);
+    if (file_info == NULL)
+        return 0;
+
+    return g_file_info_get_size(file_info);
 }

--- a/src/pu-file.h
+++ b/src/pu-file.h
@@ -14,5 +14,10 @@ gboolean pu_file_read_raw(const gchar *filename,
                           gssize count,
                           gsize *bytes_read,
                           GError **error);
+gboolean pu_file_copy(const gchar *src,
+                      const gchar *dest,
+                      GError **error);
+goffset pu_file_get_size(const gchar *path,
+                         GError **error);
 
 #endif /* PARTUP_FILE_H */

--- a/src/pu-log.c
+++ b/src/pu-log.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include "pu-log.h"
 
-#define PU_LOG_DOMAINS "partup partup-config partup-emmc partup-mount partup-package partup-utils"
+#define PU_LOG_DOMAINS "partup partup-config partup-emmc partup-file partup-mount partup-package partup-utils"
 
 GLogLevelFlags log_output_level = G_LOG_LEVEL_INFO;
 

--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -57,28 +57,6 @@ pu_spawn_command_line_sync(const gchar *command_line,
 }
 
 gboolean
-pu_file_copy(const gchar *src,
-             const gchar *dest,
-             GError **error)
-{
-    g_autoptr(GFile) in = NULL;
-    g_autofree gchar *out_path = NULL;
-    g_autoptr(GFile) out = NULL;
-
-    g_return_val_if_fail(src != NULL, FALSE);
-    g_return_val_if_fail(dest != NULL, FALSE);
-    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
-
-    g_debug("Copying '%s' to '%s'", src, dest);
-
-    in = g_file_new_for_path(src);
-    out_path = g_build_filename(dest, g_path_get_basename(src), NULL);
-    out = g_file_new_for_path(out_path);
-
-    return g_file_copy(in, out, G_FILE_COPY_NONE, NULL, NULL, NULL, error);
-}
-
-gboolean
 pu_archive_extract(const gchar *filename,
                    const gchar *dest,
                    GError **error)
@@ -496,25 +474,6 @@ pu_set_bootbus(const gchar *device,
         return FALSE;
 
     return TRUE;
-}
-
-goffset
-pu_get_file_size(const gchar *path,
-                 GError **error)
-{
-    g_autoptr(GFile) file = NULL;
-    g_autoptr(GFileInfo) file_info = NULL;
-
-    g_return_val_if_fail(g_strcmp0(path, "") > 0, 0);
-    g_return_val_if_fail(error == NULL || *error == NULL, 0);
-
-    file = g_file_new_for_path(path);
-    file_info = g_file_query_info(file, G_FILE_ATTRIBUTE_STANDARD_SIZE,
-                                  G_FILE_QUERY_INFO_NONE, NULL, error);
-    if (file_info == NULL)
-        return 0;
-
-    return g_file_info_get_size(file_info);
 }
 
 gchar *

--- a/src/pu-utils.h
+++ b/src/pu-utils.h
@@ -11,9 +11,6 @@
 
 gboolean pu_spawn_command_line_sync(const gchar *command_line,
                                     GError **error);
-gboolean pu_file_copy(const gchar *src,
-                      const gchar *dest,
-                      GError **error);
 gboolean pu_archive_extract(const gchar *filename,
                             const gchar *dest,
                             GError **error);
@@ -57,8 +54,6 @@ gboolean pu_set_hwreset(const gchar *device,
 gboolean pu_set_bootbus(const gchar *device,
                         const gchar *bootbus,
                         GError **error);
-goffset pu_get_file_size(const gchar *path,
-                         GError **error);
 gchar * pu_path_from_filename(const gchar *filename,
                               const gchar *prefix,
                               GError **error);

--- a/tests/file.c
+++ b/tests/file.c
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2024 PHYTEC Messtechnik GmbH
+ */
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <gio/gio.h>
+#include "pu-file.h"
+#include "pu-error.h"
+
+#define ROOT_EXT4_SIZE 262144
+
+static void
+test_file_copy(void)
+{
+    g_autoptr(GError) error = NULL;
+    g_autofree gchar *dest = NULL;
+    g_autofree gchar *out_file = NULL;
+    const gchar *source = "data/lorem.txt";
+
+    dest = g_dir_make_tmp("partup-XXXXXX", &error);
+    g_assert_no_error(error);
+
+    out_file = g_build_filename(dest, "lorem.txt", NULL);
+
+    g_assert_true(pu_file_copy(source, dest, &error));
+    g_assert_no_error(error);
+    g_assert_true(g_file_test(out_file, G_FILE_TEST_IS_REGULAR));
+
+    g_assert_cmpint(g_remove(out_file), ==, 0);
+    g_assert_cmpint(g_rmdir(dest), ==, 0);
+}
+
+static void
+test_file_copy_fail(void)
+{
+    g_autoptr(GError) error = NULL;
+    g_autofree gchar *dest = NULL;
+    g_autofree gchar *out_file = NULL;
+    const gchar *source = "data/thisfilereallydoesnotexist";
+
+    dest = g_dir_make_tmp("partup-XXXXXX", &error);
+    g_assert_no_error(error);
+
+    g_assert_false(pu_file_copy(source, dest, &error));
+    g_assert_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
+
+    g_assert_cmpint(g_rmdir(dest), ==, 0);
+}
+
+static void
+test_file_get_size(void)
+{
+    g_autoptr(GError) error = NULL;
+    goffset size = pu_file_get_size("data/root.ext4", &error);
+    g_assert_no_error(error);
+    g_assert_cmpuint(size, ==, ROOT_EXT4_SIZE);
+}
+
+int
+main(int argc,
+     char *argv[])
+{
+    g_test_init(&argc, &argv, NULL);
+
+#ifdef PARTUP_TEST_SRCDIR
+    g_chdir(PARTUP_TEST_SRCDIR);
+#endif
+
+    g_test_add_func("/file/file_copy", test_file_copy);
+    g_test_add_func("/file/file_copy_fail", test_file_copy_fail);
+    g_test_add_func("/file/file_get_size", test_file_get_size);
+
+    return g_test_run();
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3,6 +3,7 @@ tests = [
   'command',
   'config',
   'emmc',
+  'file',
   'package',
   'utils'
 ]

--- a/tests/utils.c
+++ b/tests/utils.c
@@ -11,46 +11,6 @@
 #include "pu-utils.h"
 #include "pu-error.h"
 
-#define ROOT_EXT4_SIZE 262144
-
-static void
-test_file_copy(void)
-{
-    g_autoptr(GError) error = NULL;
-    g_autofree gchar *dest = NULL;
-    g_autofree gchar *out_file = NULL;
-    const gchar *source = "data/lorem.txt";
-
-    dest = g_dir_make_tmp("partup-XXXXXX", &error);
-    g_assert_no_error(error);
-
-    out_file = g_build_filename(dest, "lorem.txt", NULL);
-
-    g_assert_true(pu_file_copy(source, dest, &error));
-    g_assert_no_error(error);
-    g_assert_true(g_file_test(out_file, G_FILE_TEST_IS_REGULAR));
-
-    g_assert_cmpint(g_remove(out_file), ==, 0);
-    g_assert_cmpint(g_rmdir(dest), ==, 0);
-}
-
-static void
-test_file_copy_fail(void)
-{
-    g_autoptr(GError) error = NULL;
-    g_autofree gchar *dest = NULL;
-    g_autofree gchar *out_file = NULL;
-    const gchar *source = "data/thisfilereallydoesnotexist";
-
-    dest = g_dir_make_tmp("partup-XXXXXX", &error);
-    g_assert_no_error(error);
-
-    g_assert_false(pu_file_copy(source, dest, &error));
-    g_assert_error(error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND);
-
-    g_assert_cmpint(g_rmdir(dest), ==, 0);
-}
-
 static void
 test_archive_extract(void)
 {
@@ -202,15 +162,6 @@ test_device_get_partition_path_fail(void)
 }
 
 static void
-test_get_file_size(void)
-{
-    g_autoptr(GError) error = NULL;
-    goffset size = pu_get_file_size("data/root.ext4", &error);
-    g_assert_no_error(error);
-    g_assert_cmpuint(size, ==, ROOT_EXT4_SIZE);
-}
-
-static void
 test_str_pre_remove(void)
 {
     g_autofree gchar *in = g_strdup("partup");
@@ -253,8 +204,6 @@ main(int argc,
     g_chdir(PARTUP_TEST_SRCDIR);
 #endif
 
-    g_test_add_func("/utils/file_copy", test_file_copy);
-    g_test_add_func("/utils/file_copy_fail", test_file_copy_fail);
     g_test_add_func("/utils/archive_extract", test_archive_extract);
     g_test_add("/utils/make_filesystem", EmptyFileFixture, "file", empty_file_set_up,
                test_make_filesystem, empty_file_tear_down);
@@ -272,8 +221,6 @@ main(int argc,
                     test_device_get_partition_path_sd);
     g_test_add_func("/utils/device_get_partition_path_fail",
                     test_device_get_partition_path_fail);
-    g_test_add_func("/utils/get_file_size",
-                    test_get_file_size);
     g_test_add_func("/utils/str_pre_remove", test_str_pre_remove);
     g_test_add_func("/utils/device_get_partition_pattern", test_device_get_partition_pattern);
 


### PR DESCRIPTION
Move the file related functions pu_file_copy() and pu_file_get_size() to the pu-file module. While at it, rename pu_get_file_size() to pu_file_get_size() for consistency in naming.

Create a new module "file" for all file-related unit tests and use the new file module from the sources for it.