### PR TITLE
github: workflows: use self-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted-ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Install build dependencies

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted-ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   system-tests:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted-ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Install build dependencies

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted-ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Install build dependencies


### PR DESCRIPTION
We currently only have ubuntu 22.04 but will also update soon. This is
an initial test, to see everything is working.

Signed-off-by: Stefan Müller-Klieser <s.mueller-klieser@phytec.de>
