### PR TITLE
src: emmc: Verify checksum of written eMMC boot partition data

### DIFF
--- a/doc/layout-config-reference.rst
+++ b/doc/layout-config-reference.rst
@@ -75,10 +75,15 @@ Raw Data
 ........
 
 The section ``raw`` contains a sequence of mappings describing data that is
-written outside of partitions. Each entry may contain the following options:
+written outside of partitions.
 
-Since :ref:`release-2.1.0`, the written output is also being verified by
-checking against the input's SHA256 sum, including any given offsets.
+Since :ref:`release-2.1.0`, the written output is always being verified by
+checking against the input's SHA256 sum, including any given offsets. The
+checksum is not being verified when ``--skip-checksum`` is given as a runtime
+argument. Note, that this checksum is indenpendent from the input's
+``sha256sum`` option.
+
+Each raw entry may contain the following options:
 
 ``input-offset`` (integer/string)
    Offset of the input data to be written.
@@ -207,6 +212,12 @@ eMMC's special boot partitions can be specified using the keyword
 Binary files are specified by a scalar named ``binaries`` containing a sequence
 of mappings with at least an ``input``.
 
+Since :ref:`release-3.0.0`, the written output is always being verified by
+checking against the input's SHA256 sum, including any given offsets. The
+checksum is not being verified when ``--skip-checksum`` is given as a runtime
+argument. Note, that this checksum is indenpendent from the input's
+``sha256sum`` option.
+
 ``input-offset`` (integer/string)
    Offset of the input data to be written. This keyword is optional.
 
@@ -264,7 +275,7 @@ Input Files
 -----------
 
 Input files are specified by a scalar named ``input`` containing a mapping with
-at least a ``filename``. For verifying the checksum of the given file by
+at least a ``filename``. For verifying the checksum of the given input file by
 ``filename``, an optional checksum can be provided with ``md5sum`` and/or
 ``sha256sum``.
 

--- a/src/pu-checksum.c
+++ b/src/pu-checksum.c
@@ -76,6 +76,28 @@ pu_checksum_verify_raw(const gchar *filename,
     return TRUE;
 }
 
+gboolean
+pu_checksum_verify_raw_bootpart(const gchar *device,
+                                guint bootpart,
+                                goffset offset,
+                                gsize size,
+                                const gchar *checksum,
+                                GChecksumType checksum_type,
+                                GError **error)
+{
+    g_autofree gchar *bootpart_device = NULL;
+
+    g_return_val_if_fail(g_regex_match_simple("(mmcblk)[0-9]+$", device, 0, 0), FALSE);
+    g_return_val_if_fail(bootpart <= 1, FALSE);
+    g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+    bootpart_device = g_strdup_printf("%sboot%d", device, bootpart);
+
+    return pu_checksum_verify_raw(bootpart_device, offset, size, checksum,
+                                  checksum_type, error);
+}
+
+
 gchar *
 pu_checksum_new_from_file(const gchar *filename,
                           goffset offset,

--- a/src/pu-checksum.h
+++ b/src/pu-checksum.h
@@ -19,6 +19,13 @@ gboolean pu_checksum_verify_raw(const gchar *filename,
                                 const gchar *checksum,
                                 GChecksumType checksum_type,
                                 GError **error);
+gboolean pu_checksum_verify_raw_bootpart(const gchar *device,
+                                         guint bootpart,
+                                         goffset offset,
+                                         gsize size,
+                                         const gchar *checksum,
+                                         GChecksumType checksum_type,
+                                         GError **error);
 gchar * pu_checksum_new_from_file(const gchar *filename,
                                   goffset offset,
                                   GChecksumType checksum_type,


### PR DESCRIPTION
For binary data in eMMC boot partitions, verify the written output data, in addition to the already existing input verification. This adds the same output verification as exists for the "raw" section.

First, a checksum is created of the input file while accounting any input offset. Then the data is written as usual to the device. Finally, the written data is verified at the specified output offset against the previously determined checksum.

Describe, how the raw and eMMC boot partition output data is being verified. Add a note, that this checksum verification is independent of the provided checksums in "input".