### PR TITLE
Set default partition filesystem to null and add unit tests for it

### DIFF
--- a/doc/layout-config-reference.rst
+++ b/doc/layout-config-reference.rst
@@ -144,8 +144,20 @@ options:
 ``filesystem`` (string)
    The filesystem type to use during formatting of the partition.
 
+   It is possible to set ``filesystem`` to ``null``. This is useful for writing
+   raw images -- already containing a filesystem -- directly to a partition. For
+   additional information see :ref:`supported-file-types`.
+
+   When no filesystem is specified, the default is ``null``.
+
+   .. note::
+
+      Versions prior to partup :ref:`release-4.0.0` used ``fat32`` as the
+      default filesystem.
+
    The following filesystems are currently supported:
 
+   - ``null`` (default)
    - ``ext2``
    - ``ext3``
    - ``ext4``
@@ -335,6 +347,8 @@ at least a ``filename``. For verifying the checksum of the given input file by
    The SHA256 sum of the given file specified by ``filename``. This sum is
    checked against the provided file before writing to the target partition or
    volume.
+
+.. _supported-file-types:
 
 Supported File Types
 ....................

--- a/src/pu-emmc.c
+++ b/src/pu-emmc.c
@@ -977,7 +977,7 @@ pu_emmc_parse_partitions(PuEmmc *emmc,
         PuEmmcPartition *part = g_new0(PuEmmcPartition, 1);
         part->label = pu_hash_table_lookup_string(v->data.mapping, "label", NULL);
         part->partuuid = pu_hash_table_lookup_string(v->data.mapping, "partuuid", "");
-        part->filesystem = pu_hash_table_lookup_string(v->data.mapping, "filesystem", "fat32");
+        part->filesystem = pu_hash_table_lookup_string(v->data.mapping, "filesystem", NULL);
         part->mkfs_extra_args = pu_hash_table_lookup_string(v->data.mapping, "mkfs-extra-args", NULL);
         part->size = pu_hash_table_lookup_sector(v->data.mapping, emmc->device, "size", 0);
         part->offset = pu_hash_table_lookup_sector(v->data.mapping, emmc->device, "offset", 0);

--- a/tests/config/gpt-partition-filesystem.yaml
+++ b/tests/config/gpt-partition-filesystem.yaml
@@ -1,0 +1,25 @@
+api-version: 1
+disklabel: gpt
+
+partitions:
+  - label: DEFAULT
+    offset: 1MiB
+    expand: true
+  - label: "NULL"
+    filesystem: null
+    expand: true
+  - label: FAT16
+    filesystem: fat16
+    expand: true
+  - label: FAT32
+    filesystem: fat32
+    expand: true
+  - label: EXT2
+    filesystem: ext2
+    expand: true
+  - label: EXT3
+    filesystem: ext3
+    expand: true
+  - label: EXT4
+    filesystem: ext4
+    expand: true

--- a/tests/emmc-root.c
+++ b/tests/emmc-root.c
@@ -43,6 +43,37 @@ check_partition_alignment(PedDevice *dev,
     return TRUE;
 }
 
+static gboolean
+check_partition_fstype(PedDevice *dev,
+                       int part_idx,
+                       const gchar *name)
+{
+    PedDisk *disk;
+    PedPartition *part;
+    gboolean is_correct_fstype = FALSE;
+
+    disk = ped_disk_new(dev);
+    if (disk == NULL) {
+        return FALSE;
+    }
+
+    part = ped_disk_get_partition(disk, part_idx);
+    if (part == NULL) {
+        return FALSE;
+    }
+
+    if (!part->fs_type) {
+        if (!name) {
+            is_correct_fstype = TRUE;
+        }
+    } else if (g_str_equal(part->fs_type->name, name)) {
+        is_correct_fstype = TRUE;
+    }
+
+    ped_disk_destroy(disk);
+    return is_correct_fstype;
+}
+
 static void
 test_emmc_align_minimal(EmptyDeviceFixture *fixture,
                         G_GNUC_UNUSED gconstpointer user_data)
@@ -89,6 +120,37 @@ test_emmc_align_optimal(EmptyDeviceFixture *fixture,
     g_assert_true(check_partition_alignment(dev, pu_emmc_get_alignment(emmc)));
 }
 
+static void
+test_partition_filesystem(EmptyDeviceFixture *fixture,
+                          G_GNUC_UNUSED gconstpointer user_data)
+{
+    g_autoptr(PuConfig) config = NULL;
+    g_autoptr(PuEmmc) emmc = NULL;
+    PedDevice *dev = NULL;
+
+    config = pu_config_new_from_file("config/gpt-partition-filesystem.yaml",
+                                     &fixture->error);
+    g_assert_nonnull(config);
+
+    emmc = pu_emmc_new(fixture->loop_dev, config, "data", FALSE, &fixture->error);
+    g_assert_nonnull(emmc);
+
+    g_assert_true(pu_flash_init_device(PU_FLASH(emmc), &fixture->error));
+    g_assert_true(pu_flash_setup_layout(PU_FLASH(emmc), &fixture->error));
+    g_assert_true(pu_flash_write_data(PU_FLASH(emmc), &fixture->error));
+
+    dev = ped_device_get(fixture->loop_dev);
+    g_assert_nonnull(dev);
+    /* The default for "filesystem" should be "null", as per the documentation */
+    g_assert_true(check_partition_fstype(dev, 1, NULL));
+    g_assert_true(check_partition_fstype(dev, 2, NULL));
+    g_assert_true(check_partition_fstype(dev, 3, "fat16"));
+    g_assert_true(check_partition_fstype(dev, 4, "fat32"));
+    g_assert_true(check_partition_fstype(dev, 5, "ext2"));
+    g_assert_true(check_partition_fstype(dev, 6, "ext3"));
+    g_assert_true(check_partition_fstype(dev, 7, "ext4"));
+}
+
 int
 main(int argc,
      char *argv[])
@@ -107,6 +169,9 @@ main(int argc,
                test_emmc_align_minimal, empty_device_tear_down);
     g_test_add("/emmc/align_optimal", EmptyDeviceFixture, NULL, empty_device_set_up,
                test_emmc_align_optimal, empty_device_tear_down);
+    g_test_add("/emmc/partition_filesystem", EmptyDeviceFixture, NULL,
+               empty_device_set_up, test_partition_filesystem,
+               empty_device_tear_down);
 
     return g_test_run();
 }

--- a/tests/emmc-root.c
+++ b/tests/emmc-root.c
@@ -12,8 +12,9 @@
 #include "pu-error.h"
 #include "pu-utils.h"
 
-static gboolean check_partition_alignment(PedDevice *dev,
-                                          PedAlignment *alignment)
+static gboolean
+check_partition_alignment(PedDevice *dev,
+                          PedAlignment *alignment)
 {
     PedDisk *disk;
     PedPartition *part;


### PR DESCRIPTION
Fix function declaration style for check_partition_alignment().

The default filesystem for partitions is now null, instead of fat32. This is now in line with the documentation, which has been using null, too.

Add a new test for checking all supported partition filesystems, including null and the default value, which should now also be null.