### PR TITLE
Detect ext4 based on their superblock magic

### DIFF
--- a/src/pu-emmc.c
+++ b/src/pu-emmc.c
@@ -387,6 +387,9 @@ pu_emmc_write_data(PuFlash *flash,
                     return FALSE;
                 if (!pu_set_ext_label(part_path, part->label, error))
                     return FALSE;
+            } else if (!part->filesystem) {
+                if (!pu_write_raw(path, part_path, self->device, 0, 0, 0, error))
+                    return FALSE;
             } else {
                 if (!pu_mount(part_path, part_mount, NULL, NULL, error))
                     return FALSE;

--- a/src/pu-emmc.c
+++ b/src/pu-emmc.c
@@ -379,7 +379,8 @@ pu_emmc_write_data(PuFlash *flash,
                     return FALSE;
                 if (!pu_umount(part_mount, error))
                     return FALSE;
-            } else if (g_regex_match_simple(".ext[234]$", path, 0, 0)) {
+            } else if (g_regex_match_simple(".ext[234]$", path, 0, 0) ||
+                       pu_is_ext234_image(path)) {
                 if (!pu_write_raw(path, part_path, self->device, 0, 0, 0, error))
                     return FALSE;
                 if (!pu_resize_filesystem(part_path, error))

--- a/src/pu-mount.c
+++ b/src/pu-mount.c
@@ -92,6 +92,7 @@ pu_mount(const gchar *source,
          GError **error)
 {
     gint ret;
+    gint status;
     struct libmnt_context *ctx;
 
     g_return_val_if_fail(g_strcmp0(source, "") > 0, FALSE);
@@ -116,9 +117,11 @@ pu_mount(const gchar *source,
         mnt_context_append_options(ctx, options);
 
     ret = mnt_context_mount(ctx);
-    if (ret || mnt_context_get_status(ctx) != 1) {
+    status = mnt_context_get_status(ctx);
+    if (ret || status != 1) {
         g_set_error(error, PU_ERROR, PU_ERROR_MOUNT,
-                    "Failed mounting '%s' to '%s'", source, mount_point);
+                    "Failed mounting '%s' to '%s': ret %d, status %d",
+                    source, mount_point, ret, status);
         mnt_free_context(ctx);
         return FALSE;
     }
@@ -132,6 +135,7 @@ pu_umount(const gchar *mount_point,
           GError **error)
 {
     gint ret;
+    gint status;
     struct libmnt_context *ctx;
 
     g_return_val_if_fail(g_strcmp0(mount_point, "") > 0, FALSE);
@@ -148,9 +152,11 @@ pu_umount(const gchar *mount_point,
     }
     mnt_context_set_target(ctx, mount_point);
     ret = mnt_context_umount(ctx);
-    if (ret || mnt_context_get_status(ctx) != 1) {
+    status = mnt_context_get_status(ctx);
+    if (ret || status != 1) {
         g_set_error(error, PU_ERROR, PU_ERROR_MOUNT,
-                    "Failed unmounting '%s'", mount_point);
+                    "Failed unmounting '%s': ret %d, status %d",
+                    mount_point, ret, status);
         mnt_free_context(ctx);
         return FALSE;
     }

--- a/src/pu-utils.c
+++ b/src/pu-utils.c
@@ -409,6 +409,33 @@ pu_is_drive(const gchar *device)
 }
 
 gboolean
+pu_is_ext234_image(const gchar *path)
+{
+    blkid_probe pr;
+    const gchar *type = NULL;
+    gboolean ret = FALSE;
+
+    g_return_val_if_fail(g_strcmp0(path, "") > 0, FALSE);
+
+    pr = blkid_new_probe_from_filename(path);
+    if (!pr) {
+        return ret;
+    }
+
+    blkid_probe_enable_superblocks(pr, 1);
+    blkid_probe_set_superblocks_flags(pr, BLKID_SUBLKS_TYPE);
+
+    if (blkid_do_safeprobe(pr) == 0) {
+        if (blkid_probe_lookup_value(pr, "TYPE", &type, NULL) == 0) {
+            ret = (type && g_regex_match_simple("^ext[234]$", type, 0, 0));
+        }
+    }
+
+    blkid_free_probe(pr);
+    return ret;
+}
+
+gboolean
 pu_wait_for_partitions(GError **error)
 {
     g_autofree gchar *udevadm_cmd = NULL;

--- a/src/pu-utils.h
+++ b/src/pu-utils.h
@@ -47,6 +47,7 @@ gboolean pu_partition_set_partuuid(const gchar *device,
                                    const gchar *partuuid,
                                    GError **error);
 gboolean pu_is_drive(const gchar *device);
+gboolean pu_is_ext234_image(const gchar *path);
 gboolean pu_wait_for_partitions(GError **error);
 gboolean pu_set_hwreset(const gchar *device,
                         const gchar *hwreset,

--- a/tests/utils.c
+++ b/tests/utils.c
@@ -194,6 +194,17 @@ test_device_get_partition_pattern(void)
     g_assert_false(g_regex_match_simple(pattern, "/dev/sdb1", 0, 0));
 }
 
+static void
+test_is_ext234_image(void)
+{
+    g_assert_true(pu_is_ext234_image("data/root.ext4"));
+    g_assert_false(pu_is_ext234_image("data/random.bin"));
+    g_assert_false(pu_is_ext234_image("data/file-zero.txt"));
+    g_assert_false(pu_is_ext234_image("data/file-integer.txt"));
+    g_assert_false(pu_is_ext234_image("data/lorem.tar"));
+    g_assert_false(pu_is_ext234_image("data/lorem.txt"));
+}
+
 int
 main(int argc,
      char *argv[])
@@ -223,6 +234,7 @@ main(int argc,
                     test_device_get_partition_path_fail);
     g_test_add_func("/utils/str_pre_remove", test_str_pre_remove);
     g_test_add_func("/utils/device_get_partition_pattern", test_device_get_partition_pattern);
+    g_test_add_func("/utils/is_ext234_image", test_is_ext234_image);
 
     return g_test_run();
 }


### PR DESCRIPTION
Add a helper function to check a file, whether it is an ext4 image.

Detect ext4 images not only based on their filename, but also based on whether they contain an actual ext4 filesystem. This is especially needed, as sometimes ext4 images do not have a reliable filename suffix to search for. The only reliable way is to check for the superblock magic.

Add a unit test for pu_is_ext4_image and check different files.

Depends on #112 